### PR TITLE
Add button to add insulin records

### DIFF
--- a/OpenGluck Phone App/PhoneAppDelegate.swift
+++ b/OpenGluck Phone App/PhoneAppDelegate.swift
@@ -16,6 +16,7 @@ class PhoneAppDelegate: NSObject, UIApplicationDelegate, WCSessionDelegate, Obse
     )
 
     let openGlückConnection = OpenGluckConnection()
+    let sheetStatusOptions: SheetStatusViewOptions = SheetStatusViewOptions()
     private var deviceToken: String?
 
     var notificationsGranted: Bool = false

--- a/OpenGluck Phone App/PhoneAppTabs.swift
+++ b/OpenGluck Phone App/PhoneAppTabs.swift
@@ -44,6 +44,7 @@ struct PhoneAppTabs: View {
             CheckConnectionHasClient {
                 TimelineView(.everyMinute) { context in
                     CurrentGlucoseView(now: context.date)
+                    AddInsulinBrick()
                 }
             }
                 .tag(Tabs.graph)
@@ -52,9 +53,7 @@ struct PhoneAppTabs: View {
                     Text("Home")
                 }
             CheckConnectionHasClient {
-                List {
-                    LastRecordsView()
-                }
+                LastRecordsView()
             }
                 .tag(Tabs.records)
                 .tabItem {

--- a/OpenGluck Phone App/PhoneAppTabs.swift
+++ b/OpenGluck Phone App/PhoneAppTabs.swift
@@ -38,13 +38,27 @@ struct PhoneAppTabs: View {
     @AppStorage(WKDataKeys.enableContactTrick.keyValue, store: OpenGluckManager.userDefaults) var enableContactTrick: Bool = false
 #endif
     @State var currentTab: Tabs = .graph
+    @State var graphGeometry: CGSize?
 
     var body: some View {
         TabView(selection: $currentTab) {
             CheckConnectionHasClient {
                 TimelineView(.everyMinute) { context in
-                    CurrentGlucoseView(now: context.date)
-                    AddInsulinBrick()
+                    Grid {
+                        GridRow {
+                            Color.clear
+                                .gridCellUnsizedAxes([.vertical, .horizontal])
+                            AddInsulinBrick()
+                        }
+                        GridRow {
+                            CurrentGlucoseView(now: context.date, mode: .graphBrick, graphGeometry: $graphGeometry)
+                                .gridCellColumns(2)
+                        }
+                        GridRow {
+                            GlucoseTrendBrick(graphGeometry: graphGeometry)
+                            CurrentGlucoseBrick(now: context.date)
+                        }
+                    }
                 }
             }
                 .tag(Tabs.graph)

--- a/OpenGluck Phone App/PhoneAppTabs.swift
+++ b/OpenGluck Phone App/PhoneAppTabs.swift
@@ -67,7 +67,9 @@ struct PhoneAppTabs: View {
                     Text("Home")
                 }
             CheckConnectionHasClient {
-                LastRecordsView()
+                List {
+                    LastRecordsView()
+                }
             }
                 .tag(Tabs.records)
                 .tabItem {

--- a/OpenGluck Phone App/PhoneContentView.swift
+++ b/OpenGluck Phone App/PhoneContentView.swift
@@ -7,12 +7,14 @@ struct PhoneContentView: View {
         AppDataAutoFetch {
             OpenGluckEnvironmentUpdater {
                 VStack {
+                    SheetStatusView()
                     //WKDataDebugView()
                     PhoneAppTabs()
                 }
             }
         }
         .environmentObject(appDelegate.openGlückConnection)
+        .environmentObject(appDelegate.sheetStatusOptions)
         .padding()
     }
 }

--- a/OpenGluck Watch App/WatchContentView.swift
+++ b/OpenGluck Watch App/WatchContentView.swift
@@ -10,20 +10,25 @@ struct WatchContentView: View {
     @State var graphGeometry: CGSize?
     
     var body: some View {
-        TimelineView(.everyMinute) { context in
-            OpenGluckEnvironmentUpdater {
-                ScrollView {
-                    //WKDataDebugView()
-                    //WKComplicationDebugView()
-                    Group {
-                        CurrentGlucoseView(now: context.date, graphGeometry: $graphGeometry)
-                            .padding(.bottom, 10)
-                            // LATER improve use watchOS 10
-                            .frame(minHeight: 190)
+        OpenGluckEnvironmentUpdater {
+            List {
+                TimelineView(.everyMinute) { context in
+                    Grid {
+                        GridRow {
+                            CurrentGlucoseView(now: context.date, mode: .graph, graphGeometry: $graphGeometry)
+                                .frame(height: 120)
+                                .gridCellColumns(2)
+                        }
+                        GridRow {
+                            GlucoseTrend(graphGeometry: graphGeometry)
+                            CurrentGlucose(now: context.date)
+                        }
+                        .padding(.all)
                     }
-                    LastRecordsView()
-                        .padding(.vertical)
                 }
+                .padding(.horizontal, -15)
+                .listItemTint(.clear)
+                LastRecordsView()
             }
         }
     }

--- a/OpenGluck Watch App/WatchContentView.swift
+++ b/OpenGluck Watch App/WatchContentView.swift
@@ -7,6 +7,7 @@ struct WatchContentView: View {
     
     @AppStorage(WKDataKeys.openglückUrl.keyValue, store: OpenGluckManager.userDefaults) var openglückUrl: String = ""
     @AppStorage(WKDataKeys.openglückToken.keyValue, store: OpenGluckManager.userDefaults) var openglückToken: String = ""
+    @State var graphGeometry: CGSize?
     
     var body: some View {
         TimelineView(.everyMinute) { context in
@@ -15,7 +16,7 @@ struct WatchContentView: View {
                     //WKDataDebugView()
                     //WKComplicationDebugView()
                     Group {
-                        CurrentGlucoseView(now: context.date)
+                        CurrentGlucoseView(now: context.date, graphGeometry: $graphGeometry)
                             .padding(.bottom, 10)
                             // LATER improve use watchOS 10
                             .frame(minHeight: 190)

--- a/OpenGluck.xcodeproj/project.pbxproj
+++ b/OpenGluck.xcodeproj/project.pbxproj
@@ -183,6 +183,8 @@
 		9DB44C7B29DE31A0005BB7F8 /* WKComplicationDebugView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DB44C7A29DE31A0005BB7F8 /* WKComplicationDebugView.swift */; };
 		9DB44C7C29DE31C0005BB7F8 /* WKComplicationDebugView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DB44C7A29DE31A0005BB7F8 /* WKComplicationDebugView.swift */; };
 		9DC4DF3E2B2F443500BAF7C5 /* SheetStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DC4DF3D2B2F443500BAF7C5 /* SheetStatusView.swift */; };
+		9DC4DF402B2F62FC00BAF7C5 /* GlucoseTrendBrick.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DC4DF3F2B2F62FC00BAF7C5 /* GlucoseTrendBrick.swift */; };
+		9DC4DF422B2F64A500BAF7C5 /* CurrentGlucoseBrick.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DC4DF412B2F64A500BAF7C5 /* CurrentGlucoseBrick.swift */; };
 		9DCAE26729CCED0F005973F8 /* OpenGluckCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DCAE26629CCED0F005973F8 /* OpenGluckCredentials.swift */; };
 		9DCAE26829CCED0F005973F8 /* OpenGluckCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DCAE26629CCED0F005973F8 /* OpenGluckCredentials.swift */; };
 		9DD650472B14AB6D00C6A417 /* Config.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 9DD650462B14AB6D00C6A417 /* Config.xcconfig */; };
@@ -353,6 +355,8 @@
 		9DB44C7929DE278A005BB7F8 /* OpenGluck Watch Widget Extension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = "OpenGluck Watch Widget Extension.entitlements"; path = "OpenGluck Watch Extension/OpenGluck Watch Widget Extension.entitlements"; sourceTree = SOURCE_ROOT; };
 		9DB44C7A29DE31A0005BB7F8 /* WKComplicationDebugView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKComplicationDebugView.swift; sourceTree = "<group>"; };
 		9DC4DF3D2B2F443500BAF7C5 /* SheetStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SheetStatusView.swift; sourceTree = "<group>"; };
+		9DC4DF3F2B2F62FC00BAF7C5 /* GlucoseTrendBrick.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlucoseTrendBrick.swift; sourceTree = "<group>"; };
+		9DC4DF412B2F64A500BAF7C5 /* CurrentGlucoseBrick.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentGlucoseBrick.swift; sourceTree = "<group>"; };
 		9DCAE26629CCED0F005973F8 /* OpenGluckCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenGluckCredentials.swift; sourceTree = "<group>"; };
 		9DCAE26929CD0944005973F8 /* WatchUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchUpdater.swift; sourceTree = "<group>"; };
 		9DD650462B14AB6D00C6A417 /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
@@ -429,6 +433,8 @@
 			children = (
 				9D1F6EB02B27404D0070D7A3 /* AddInsulinBrick.swift */,
 				9D1F6EB22B27417D0070D7A3 /* Brick.swift */,
+				9DC4DF3F2B2F62FC00BAF7C5 /* GlucoseTrendBrick.swift */,
+				9DC4DF412B2F64A500BAF7C5 /* CurrentGlucoseBrick.swift */,
 			);
 			path = Bricks;
 			sourceTree = "<group>";
@@ -1032,8 +1038,10 @@
 				9D39BB0B2A043C180037AB00 /* WKDataKeys.swift in Sources */,
 				9D2DFED929D0EF8A00545193 /* PhoneAdvancedView.swift in Sources */,
 				9D192C8E29C8EFF00047E40E /* NumberImageView.swift in Sources */,
+				9DC4DF422B2F64A500BAF7C5 /* CurrentGlucoseBrick.swift in Sources */,
 				9D1F6EB12B27404D0070D7A3 /* AddInsulinBrick.swift in Sources */,
 				9D1B2CB929DCC163004C6311 /* ComplicationDebugView.swift in Sources */,
+				9DC4DF402B2F62FC00BAF7C5 /* GlucoseTrendBrick.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/OpenGluck.xcodeproj/project.pbxproj
+++ b/OpenGluck.xcodeproj/project.pbxproj
@@ -43,6 +43,12 @@
 		9D1EEE512AEF9FC2009EA2AB /* OpenGluckThresholdsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D1EEE4F2AEF9FC2009EA2AB /* OpenGluckThresholdsDelegate.swift */; };
 		9D1EEE522AEF9FC2009EA2AB /* OpenGluckThresholdsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D1EEE4F2AEF9FC2009EA2AB /* OpenGluckThresholdsDelegate.swift */; };
 		9D1EEE532AEF9FC2009EA2AB /* OpenGluckThresholdsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D1EEE4F2AEF9FC2009EA2AB /* OpenGluckThresholdsDelegate.swift */; };
+		9D1F6EB12B27404D0070D7A3 /* AddInsulinBrick.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D1F6EB02B27404D0070D7A3 /* AddInsulinBrick.swift */; };
+		9D1F6EB32B27417D0070D7A3 /* Brick.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D1F6EB22B27417D0070D7A3 /* Brick.swift */; };
+		9D1F6EB42B2741DD0070D7A3 /* Brick.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D1F6EB22B27417D0070D7A3 /* Brick.swift */; };
+		9D1F6EB52B2741DD0070D7A3 /* Brick.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D1F6EB22B27417D0070D7A3 /* Brick.swift */; };
+		9D1F6EB62B2741DE0070D7A3 /* Brick.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D1F6EB22B27417D0070D7A3 /* Brick.swift */; };
+		9D1F6EB72B2741DE0070D7A3 /* Brick.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D1F6EB22B27417D0070D7A3 /* Brick.swift */; };
 		9D2268812AF29B2700437FAC /* OpenGluckTvApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D2268802AF29B2700437FAC /* OpenGluckTvApp.swift */; };
 		9D2268832AF29B2700437FAC /* TvContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D2268822AF29B2700437FAC /* TvContentView.swift */; };
 		9D2268852AF29B2800437FAC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9D2268842AF29B2800437FAC /* Assets.xcassets */; };
@@ -149,6 +155,15 @@
 		9DA6CF6A29E34F2A0075CC4C /* PhoneWidgetTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DA6CF6929E34F2A0075CC4C /* PhoneWidgetTarget.swift */; };
 		9DA6CF6B29E34F440075CC4C /* NumberImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D192C8D29C8EFF00047E40E /* NumberImageView.swift */; };
 		9DA6CF6E29E3575E0075CC4C /* CurrentBloodGlucoseTimestampWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DA6CF6C29E355720075CC4C /* CurrentBloodGlucoseTimestampWidget.swift */; };
+		9DA7CCA82B290AB80006EC91 /* InsulinRecordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DA7CCA72B290AB80006EC91 /* InsulinRecordView.swift */; };
+		9DA7CCAA2B290B070006EC91 /* InsulinUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DA7CCA92B290B070006EC91 /* InsulinUnit.swift */; };
+		9DA7CCAD2B290D570006EC91 /* LowRecordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DA7CCAC2B290D570006EC91 /* LowRecordView.swift */; };
+		9DA7CCAF2B290DB00006EC91 /* SnackGram.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DA7CCAE2B290DB00006EC91 /* SnackGram.swift */; };
+		9DA7CCB02B290F520006EC91 /* LowRecordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DA7CCAC2B290D570006EC91 /* LowRecordView.swift */; };
+		9DA7CCB12B290F530006EC91 /* InsulinRecordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DA7CCA72B290AB80006EC91 /* InsulinRecordView.swift */; };
+		9DA7CCB22B290F580006EC91 /* InsulinUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DA7CCA92B290B070006EC91 /* InsulinUnit.swift */; };
+		9DA7CCB32B290F5B0006EC91 /* SnackGram.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DA7CCAE2B290DB00006EC91 /* SnackGram.swift */; };
+		9DA7CCB52B29118D0006EC91 /* HoldButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DA7CCB42B29118D0006EC91 /* HoldButton.swift */; };
 		9DAD39232AF5AD4700C1304F /* OpenGluckConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DAD39212AF5AD4600C1304F /* OpenGluckConnection.swift */; };
 		9DAD39242AF5AD4700C1304F /* OpenGluckConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DAD39212AF5AD4600C1304F /* OpenGluckConnection.swift */; };
 		9DAD39252AF5AD4700C1304F /* OpenGluckConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DAD39212AF5AD4600C1304F /* OpenGluckConnection.swift */; };
@@ -167,6 +182,7 @@
 		9DB1DD352B07CD3E007ED12B /* BloodGlucose.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DB1DD302B07CD3E007ED12B /* BloodGlucose.swift */; };
 		9DB44C7B29DE31A0005BB7F8 /* WKComplicationDebugView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DB44C7A29DE31A0005BB7F8 /* WKComplicationDebugView.swift */; };
 		9DB44C7C29DE31C0005BB7F8 /* WKComplicationDebugView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DB44C7A29DE31A0005BB7F8 /* WKComplicationDebugView.swift */; };
+		9DC4DF3E2B2F443500BAF7C5 /* SheetStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DC4DF3D2B2F443500BAF7C5 /* SheetStatusView.swift */; };
 		9DCAE26729CCED0F005973F8 /* OpenGluckCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DCAE26629CCED0F005973F8 /* OpenGluckCredentials.swift */; };
 		9DCAE26829CCED0F005973F8 /* OpenGluckCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DCAE26629CCED0F005973F8 /* OpenGluckCredentials.swift */; };
 		9DD650472B14AB6D00C6A417 /* Config.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 9DD650462B14AB6D00C6A417 /* Config.xcconfig */; };
@@ -263,6 +279,8 @@
 		9D1B2CBA29DCC3DF004C6311 /* WidgetKinds.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetKinds.swift; sourceTree = "<group>"; };
 		9D1EEE4D2AEF9F58009EA2AB /* DisplayPreferencesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DisplayPreferencesView.swift; path = "OpenGluck Phone App/DisplayPreferencesView.swift"; sourceTree = SOURCE_ROOT; };
 		9D1EEE4F2AEF9FC2009EA2AB /* OpenGluckThresholdsDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = OpenGluckThresholdsDelegate.swift; path = OpenGluck/OpenGluck/OpenGluckThresholdsDelegate.swift; sourceTree = SOURCE_ROOT; };
+		9D1F6EB02B27404D0070D7A3 /* AddInsulinBrick.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddInsulinBrick.swift; sourceTree = "<group>"; };
+		9D1F6EB22B27417D0070D7A3 /* Brick.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Brick.swift; sourceTree = "<group>"; };
 		9D22687E2AF29B2700437FAC /* OG TV.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "OG TV.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		9D2268802AF29B2700437FAC /* OpenGluckTvApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenGluckTvApp.swift; sourceTree = "<group>"; };
 		9D2268822AF29B2700437FAC /* TvContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TvContentView.swift; sourceTree = "<group>"; };
@@ -323,12 +341,18 @@
 		9D93A23F2A1A09E900F644B2 /* GlucoseNumbersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlucoseNumbersView.swift; sourceTree = "<group>"; };
 		9DA6CF6929E34F2A0075CC4C /* PhoneWidgetTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneWidgetTarget.swift; sourceTree = "<group>"; };
 		9DA6CF6C29E355720075CC4C /* CurrentBloodGlucoseTimestampWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentBloodGlucoseTimestampWidget.swift; sourceTree = "<group>"; };
+		9DA7CCA72B290AB80006EC91 /* InsulinRecordView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsulinRecordView.swift; sourceTree = "<group>"; };
+		9DA7CCA92B290B070006EC91 /* InsulinUnit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsulinUnit.swift; sourceTree = "<group>"; };
+		9DA7CCAC2B290D570006EC91 /* LowRecordView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LowRecordView.swift; sourceTree = "<group>"; };
+		9DA7CCAE2B290DB00006EC91 /* SnackGram.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnackGram.swift; sourceTree = "<group>"; };
+		9DA7CCB42B29118D0006EC91 /* HoldButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoldButton.swift; sourceTree = "<group>"; };
 		9DABAE8B29D8E1EA00315030 /* OpenGluck Watch.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "OpenGluck Watch.entitlements"; sourceTree = "<group>"; };
 		9DAD39212AF5AD4600C1304F /* OpenGluckConnection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenGluckConnection.swift; sourceTree = "<group>"; };
 		9DAD39222AF5AD4700C1304F /* OpenGluckEnvironmentUpdater.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenGluckEnvironmentUpdater.swift; sourceTree = "<group>"; };
 		9DB1DD302B07CD3E007ED12B /* BloodGlucose.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BloodGlucose.swift; sourceTree = "<group>"; };
 		9DB44C7929DE278A005BB7F8 /* OpenGluck Watch Widget Extension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = "OpenGluck Watch Widget Extension.entitlements"; path = "OpenGluck Watch Extension/OpenGluck Watch Widget Extension.entitlements"; sourceTree = SOURCE_ROOT; };
 		9DB44C7A29DE31A0005BB7F8 /* WKComplicationDebugView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKComplicationDebugView.swift; sourceTree = "<group>"; };
+		9DC4DF3D2B2F443500BAF7C5 /* SheetStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SheetStatusView.swift; sourceTree = "<group>"; };
 		9DCAE26629CCED0F005973F8 /* OpenGluckCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenGluckCredentials.swift; sourceTree = "<group>"; };
 		9DCAE26929CD0944005973F8 /* WatchUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchUpdater.swift; sourceTree = "<group>"; };
 		9DD650462B14AB6D00C6A417 /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
@@ -400,6 +424,15 @@
 			path = Widgets;
 			sourceTree = "<group>";
 		};
+		9D1F6EAF2B2740390070D7A3 /* Bricks */ = {
+			isa = PBXGroup;
+			children = (
+				9D1F6EB02B27404D0070D7A3 /* AddInsulinBrick.swift */,
+				9D1F6EB22B27417D0070D7A3 /* Brick.swift */,
+			);
+			path = Bricks;
+			sourceTree = "<group>";
+		};
 		9D22687F2AF29B2700437FAC /* TV */ = {
 			isa = PBXGroup;
 			children = (
@@ -446,6 +479,8 @@
 		9D2F2FA82A3074F60025A3D3 /* Records */ = {
 			isa = PBXGroup;
 			children = (
+				9DA7CCAB2B290D4C0006EC91 /* Low */,
+				9DA7CCA62B290A9E0006EC91 /* Insulin */,
 				9D786CBD29CE34FE008F9270 /* Glucose */,
 				9D2F2FA92A3075140025A3D3 /* TimestampView.swift */,
 			);
@@ -564,6 +599,7 @@
 				9D657A1729DAEF4600791926 /* ContactUpdater */,
 				9D2F2FA82A3074F60025A3D3 /* Records */,
 				9DF375DD29D2548A0043CAA6 /* Utils */,
+				9D1F6EAF2B2740390070D7A3 /* Bricks */,
 				9D8AD5EC2A3B1046006FEAE0 /* Widgets */,
 				9D0B4BB02AFFF21000D2C773 /* AppData.swift */,
 				9D0B4BB62B002F4700D2C773 /* Media.xcassets */,
@@ -654,10 +690,30 @@
 			path = OpenGluck;
 			sourceTree = "<group>";
 		};
+		9DA7CCA62B290A9E0006EC91 /* Insulin */ = {
+			isa = PBXGroup;
+			children = (
+				9DA7CCA72B290AB80006EC91 /* InsulinRecordView.swift */,
+			);
+			path = Insulin;
+			sourceTree = "<group>";
+		};
+		9DA7CCAB2B290D4C0006EC91 /* Low */ = {
+			isa = PBXGroup;
+			children = (
+				9DA7CCAC2B290D570006EC91 /* LowRecordView.swift */,
+			);
+			path = Low;
+			sourceTree = "<group>";
+		};
 		9DB1DD2F2B07CD0A007ED12B /* UI */ = {
 			isa = PBXGroup;
 			children = (
 				9DB1DD302B07CD3E007ED12B /* BloodGlucose.swift */,
+				9DA7CCA92B290B070006EC91 /* InsulinUnit.swift */,
+				9DA7CCAE2B290DB00006EC91 /* SnackGram.swift */,
+				9DA7CCB42B29118D0006EC91 /* HoldButton.swift */,
+				9DC4DF3D2B2F443500BAF7C5 /* SheetStatusView.swift */,
 			);
 			path = UI;
 			sourceTree = "<group>";
@@ -925,6 +981,7 @@
 				9D2268982AF29D7B00437FAC /* WKDataKeys.swift in Sources */,
 				9D2268A42AF2B4FD00437FAC /* CurrentDataColors.swift in Sources */,
 				9D0B4BB52AFFF21000D2C773 /* AppData.swift in Sources */,
+				9D1F6EB72B2741DE0070D7A3 /* Brick.swift in Sources */,
 				9D2268912AF29CD600437FAC /* CurrentGlucoseView.swift in Sources */,
 				9DB1DD352B07CD3E007ED12B /* BloodGlucose.swift in Sources */,
 				9D2268972AF29D4500437FAC /* OpenGluckManager.swift in Sources */,
@@ -941,6 +998,7 @@
 				9DF375E229D256740043CAA6 /* LastRecordsView.swift in Sources */,
 				9D0B4BB12AFFF21000D2C773 /* AppData.swift in Sources */,
 				9D93A2402A1A09E900F644B2 /* GlucoseNumbersView.swift in Sources */,
+				9D1F6EB32B27417D0070D7A3 /* Brick.swift in Sources */,
 				9D50EBAD29C79E2300CF69E6 /* PhoneContentView.swift in Sources */,
 				9D50EBD129C7A7A300CF69E6 /* HTTPSClient.swift in Sources */,
 				9D192C8C29C8EAD00047E40E /* PhoneContactUpdater.swift in Sources */,
@@ -952,22 +1010,29 @@
 				9DAD39232AF5AD4700C1304F /* OpenGluckConnection.swift in Sources */,
 				9D332E2929D6130B002613F6 /* WKData.swift in Sources */,
 				9D657A1429DABD9800791926 /* PhoneAppDelegate.swift in Sources */,
+				9DA7CCAA2B290B070006EC91 /* InsulinUnit.swift in Sources */,
 				9D50EBAB29C79E2300CF69E6 /* OpenGluckPhoneApp.swift in Sources */,
 				9D50EBD429C7A7F200CF69E6 /* CurrentGlucoseView.swift in Sources */,
 				9D2DFED729D0EF1000545193 /* PhoneAppTabs.swift in Sources */,
 				9DCAE26729CCED0F005973F8 /* OpenGluckCredentials.swift in Sources */,
 				9D8AD5FB2A3CB058006FEAE0 /* WidgetKinds.swift in Sources */,
+				9DC4DF3E2B2F443500BAF7C5 /* SheetStatusView.swift in Sources */,
 				9DB1DD312B07CD3E007ED12B /* BloodGlucose.swift in Sources */,
 				9D657A2229DB614F00791926 /* WKDataDebugView.swift in Sources */,
 				9D27872829E20CB3006B647F /* PhoneAppTarget.swift in Sources */,
+				9DA7CCAD2B290D570006EC91 /* LowRecordView.swift in Sources */,
 				9D657A1E29DB1DE900791926 /* WKDefaults.swift in Sources */,
+				9DA7CCA82B290AB80006EC91 /* InsulinRecordView.swift in Sources */,
 				9DF375DF29D254990043CAA6 /* OpenGluckManager.swift in Sources */,
+				9DA7CCB52B29118D0006EC91 /* HoldButton.swift in Sources */,
 				9DB44C7B29DE31A0005BB7F8 /* WKComplicationDebugView.swift in Sources */,
+				9DA7CCAF2B290DB00006EC91 /* SnackGram.swift in Sources */,
 				9D1EEE4E2AEF9F58009EA2AB /* DisplayPreferencesView.swift in Sources */,
 				9DAD39282AF5AD4700C1304F /* OpenGluckEnvironmentUpdater.swift in Sources */,
 				9D39BB0B2A043C180037AB00 /* WKDataKeys.swift in Sources */,
 				9D2DFED929D0EF8A00545193 /* PhoneAdvancedView.swift in Sources */,
 				9D192C8E29C8EFF00047E40E /* NumberImageView.swift in Sources */,
+				9D1F6EB12B27404D0070D7A3 /* AddInsulinBrick.swift in Sources */,
 				9D1B2CB929DCC163004C6311 /* ComplicationDebugView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -983,18 +1048,23 @@
 				9D2F2FAC2A3075140025A3D3 /* TimestampView.swift in Sources */,
 				9D1EEE522AEF9FC2009EA2AB /* OpenGluckThresholdsDelegate.swift in Sources */,
 				9D50EBBF29C79E2400CF69E6 /* WatchContentView.swift in Sources */,
+				9D1F6EB42B2741DD0070D7A3 /* Brick.swift in Sources */,
 				9DAD39252AF5AD4700C1304F /* OpenGluckConnection.swift in Sources */,
 				9D50EBD229C7A7A300CF69E6 /* HTTPSClient.swift in Sources */,
 				9D8AD5FF2A3DE432006FEAE0 /* NumberImageView.swift in Sources */,
 				9D786CC029CE3542008F9270 /* GlucoseGraph.swift in Sources */,
 				9D50EBDB29C7A86D00CF69E6 /* GlucoseView.swift in Sources */,
+				9DA7CCB32B290F5B0006EC91 /* SnackGram.swift in Sources */,
 				9D27872A29E20CD6006B647F /* WatchAppTarget.swift in Sources */,
+				9DA7CCB22B290F580006EC91 /* InsulinUnit.swift in Sources */,
 				9D924D382A3F33A600B477AF /* CurrentDataGauge.swift in Sources */,
 				9D1B2CBB29DCC3DF004C6311 /* WidgetKinds.swift in Sources */,
+				9DA7CCB12B290F530006EC91 /* InsulinRecordView.swift in Sources */,
 				9D657A2329DB614F00791926 /* WKDataDebugView.swift in Sources */,
 				9DF375E329D256740043CAA6 /* LastRecordsView.swift in Sources */,
 				9DAD392A2AF5AD4700C1304F /* OpenGluckEnvironmentUpdater.swift in Sources */,
 				9D657A2629DB680200791926 /* WatchAppDelegate.swift in Sources */,
+				9DA7CCB02B290F520006EC91 /* LowRecordView.swift in Sources */,
 				9D657A1A29DAF00B00791926 /* WatchUpdater.swift in Sources */,
 				9D50EBD529C7A7F200CF69E6 /* CurrentGlucoseView.swift in Sources */,
 				9D924D3D2A3F3A0200B477AF /* CurrentDataColors.swift in Sources */,
@@ -1016,6 +1086,7 @@
 				9D8AD5F92A3CAE52006FEAE0 /* CurrentGlucoseWidget.swift in Sources */,
 				9DAD39262AF5AD4700C1304F /* OpenGluckConnection.swift in Sources */,
 				9D1B2CB729DCBFBB004C6311 /* DebugWidget.swift in Sources */,
+				9D1F6EB62B2741DE0070D7A3 /* Brick.swift in Sources */,
 				9D1EEE532AEF9FC2009EA2AB /* OpenGluckThresholdsDelegate.swift in Sources */,
 				9D924D432A41DA9700B477AF /* GraphWidget.swift in Sources */,
 				9D27872C29E20CF1006B647F /* WatchComplicationTarget.swift in Sources */,
@@ -1061,6 +1132,7 @@
 				9DB1DD322B07CD3E007ED12B /* BloodGlucose.swift in Sources */,
 				9D924D442A41DC5200B477AF /* GlucoseGraph.swift in Sources */,
 				9DA6CF6629E34EBF0075CC4C /* PhoneContactUpdater.swift in Sources */,
+				9D1F6EB52B2741DD0070D7A3 /* Brick.swift in Sources */,
 				9D8AD5F22A3C5CA0006FEAE0 /* WidgetPreviewEnvironment.swift in Sources */,
 				9D8C669029E33B2A00EB40E4 /* OpenGluckManager.swift in Sources */,
 				9D924D422A41DA9700B477AF /* GraphWidget.swift in Sources */,

--- a/OpenGluck.xcodeproj/project.pbxproj
+++ b/OpenGluck.xcodeproj/project.pbxproj
@@ -185,6 +185,10 @@
 		9DC4DF3E2B2F443500BAF7C5 /* SheetStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DC4DF3D2B2F443500BAF7C5 /* SheetStatusView.swift */; };
 		9DC4DF402B2F62FC00BAF7C5 /* GlucoseTrendBrick.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DC4DF3F2B2F62FC00BAF7C5 /* GlucoseTrendBrick.swift */; };
 		9DC4DF422B2F64A500BAF7C5 /* CurrentGlucoseBrick.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DC4DF412B2F64A500BAF7C5 /* CurrentGlucoseBrick.swift */; };
+		9DC4DF442B2F6B8700BAF7C5 /* GlucoseTrend.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DC4DF432B2F6B8700BAF7C5 /* GlucoseTrend.swift */; };
+		9DC4DF462B2F6B8700BAF7C5 /* GlucoseTrend.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DC4DF432B2F6B8700BAF7C5 /* GlucoseTrend.swift */; };
+		9DC4DF4A2B2F6C2F00BAF7C5 /* CurrentGlucose.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DC4DF492B2F6C2F00BAF7C5 /* CurrentGlucose.swift */; };
+		9DC4DF4C2B2F6C2F00BAF7C5 /* CurrentGlucose.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DC4DF492B2F6C2F00BAF7C5 /* CurrentGlucose.swift */; };
 		9DCAE26729CCED0F005973F8 /* OpenGluckCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DCAE26629CCED0F005973F8 /* OpenGluckCredentials.swift */; };
 		9DCAE26829CCED0F005973F8 /* OpenGluckCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DCAE26629CCED0F005973F8 /* OpenGluckCredentials.swift */; };
 		9DD650472B14AB6D00C6A417 /* Config.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 9DD650462B14AB6D00C6A417 /* Config.xcconfig */; };
@@ -357,6 +361,8 @@
 		9DC4DF3D2B2F443500BAF7C5 /* SheetStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SheetStatusView.swift; sourceTree = "<group>"; };
 		9DC4DF3F2B2F62FC00BAF7C5 /* GlucoseTrendBrick.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlucoseTrendBrick.swift; sourceTree = "<group>"; };
 		9DC4DF412B2F64A500BAF7C5 /* CurrentGlucoseBrick.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentGlucoseBrick.swift; sourceTree = "<group>"; };
+		9DC4DF432B2F6B8700BAF7C5 /* GlucoseTrend.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlucoseTrend.swift; sourceTree = "<group>"; };
+		9DC4DF492B2F6C2F00BAF7C5 /* CurrentGlucose.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentGlucose.swift; sourceTree = "<group>"; };
 		9DCAE26629CCED0F005973F8 /* OpenGluckCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenGluckCredentials.swift; sourceTree = "<group>"; };
 		9DCAE26929CD0944005973F8 /* WatchUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchUpdater.swift; sourceTree = "<group>"; };
 		9DD650462B14AB6D00C6A417 /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
@@ -646,6 +652,8 @@
 				9DF375DA29D254360043CAA6 /* GlucoseRecordView.swift */,
 				9D924D352A3F33A600B477AF /* CurrentDataGauge.swift */,
 				9D924D3A2A3F3A0200B477AF /* CurrentDataColors.swift */,
+				9DC4DF432B2F6B8700BAF7C5 /* GlucoseTrend.swift */,
+				9DC4DF492B2F6C2F00BAF7C5 /* CurrentGlucose.swift */,
 			);
 			path = Glucose;
 			sourceTree = "<group>";
@@ -1011,6 +1019,7 @@
 				9D786CBF29CE3542008F9270 /* GlucoseGraph.swift in Sources */,
 				9D1EEE502AEF9FC2009EA2AB /* OpenGluckThresholdsDelegate.swift in Sources */,
 				9D50EBDC29C7AB7800CF69E6 /* GlucoseView.swift in Sources */,
+				9DC4DF4A2B2F6C2F00BAF7C5 /* CurrentGlucose.swift in Sources */,
 				9D924D362A3F33A600B477AF /* CurrentDataGauge.swift in Sources */,
 				9D2F2FAA2A3075140025A3D3 /* TimestampView.swift in Sources */,
 				9DAD39232AF5AD4700C1304F /* OpenGluckConnection.swift in Sources */,
@@ -1027,6 +1036,7 @@
 				9D657A2229DB614F00791926 /* WKDataDebugView.swift in Sources */,
 				9D27872829E20CB3006B647F /* PhoneAppTarget.swift in Sources */,
 				9DA7CCAD2B290D570006EC91 /* LowRecordView.swift in Sources */,
+				9DC4DF442B2F6B8700BAF7C5 /* GlucoseTrend.swift in Sources */,
 				9D657A1E29DB1DE900791926 /* WKDefaults.swift in Sources */,
 				9DA7CCA82B290AB80006EC91 /* InsulinRecordView.swift in Sources */,
 				9DF375DF29D254990043CAA6 /* OpenGluckManager.swift in Sources */,
@@ -1059,6 +1069,7 @@
 				9D1F6EB42B2741DD0070D7A3 /* Brick.swift in Sources */,
 				9DAD39252AF5AD4700C1304F /* OpenGluckConnection.swift in Sources */,
 				9D50EBD229C7A7A300CF69E6 /* HTTPSClient.swift in Sources */,
+				9DC4DF462B2F6B8700BAF7C5 /* GlucoseTrend.swift in Sources */,
 				9D8AD5FF2A3DE432006FEAE0 /* NumberImageView.swift in Sources */,
 				9D786CC029CE3542008F9270 /* GlucoseGraph.swift in Sources */,
 				9D50EBDB29C7A86D00CF69E6 /* GlucoseView.swift in Sources */,
@@ -1075,6 +1086,7 @@
 				9DA7CCB02B290F520006EC91 /* LowRecordView.swift in Sources */,
 				9D657A1A29DAF00B00791926 /* WatchUpdater.swift in Sources */,
 				9D50EBD529C7A7F200CF69E6 /* CurrentGlucoseView.swift in Sources */,
+				9DC4DF4C2B2F6C2F00BAF7C5 /* CurrentGlucose.swift in Sources */,
 				9D924D3D2A3F3A0200B477AF /* CurrentDataColors.swift in Sources */,
 				9DF375DC29D254360043CAA6 /* GlucoseRecordView.swift in Sources */,
 				9DB44C7C29DE31C0005BB7F8 /* WKComplicationDebugView.swift in Sources */,

--- a/OpenGluck/Bricks/AddInsulinBrick.swift
+++ b/OpenGluck/Bricks/AddInsulinBrick.swift
@@ -15,38 +15,34 @@ struct AddInsulinBrick: View {
         ]
         _ = try await client.upload(insulinRecords: insulinRecords)
     }
-
+    
     @State var label: String = "Add"
     var body: some View {
-        Grid {
-            GridRow {
-                Brick(title: "Insulin", systemImage: "cross.vial") {
-                    HoldButton(label: "Add")
-                    .contextMenu(ContextMenu(menuItems: {
-                        ForEach(1...16, id: \.self) { n in
-                            Button("\(n) IU") {
-                                sheetStatusOptions.state = SheetStatusViewState.inProgress
-                                sheetStatusOptions.status = "\(n) IU"
-                                sheetStatusOptions.subStatus1 = "Launching Task…"
-                                Task {
-                                    defer { sheetStatusOptions.state = SheetStatusViewState.complete }
-                                    sheetStatusOptions.subStatus1 = "Adding…"
-                                    do {
-                                        try await quickAddInsulin(units: n)
-                                        sheetStatusOptions.subStatus1 = "Done!"
-                                        NotificationCenter.default.post(name: Notification.Name.refreshOpenGlück, object: nil)
-                                    } catch {
-                                        sheetStatusOptions.pushError(message: error.localizedDescription)
-                                    }
+        Brick(title: "Insulin", systemImage: "cross.vial") {
+            HoldButton(label: "Add Insulin")
+                .contextMenu(ContextMenu(menuItems: {
+                    ForEach(1...16, id: \.self) { n in
+                        Button("\(n) IU") {
+                            sheetStatusOptions.state = SheetStatusViewState.inProgress
+                            sheetStatusOptions.status = "\(n) IU"
+                            sheetStatusOptions.subStatus1 = "Launching Task…"
+                            Task {
+                                defer { sheetStatusOptions.state = SheetStatusViewState.complete }
+                                sheetStatusOptions.subStatus1 = "Adding…"
+                                do {
+                                    try await quickAddInsulin(units: n)
+                                    sheetStatusOptions.subStatus1 = "Done!"
+                                    NotificationCenter.default.post(name: Notification.Name.refreshOpenGlück, object: nil)
+                                } catch {
+                                    sheetStatusOptions.pushError(message: error.localizedDescription)
                                 }
                             }
                         }
-                        
-                    }))
-                }
-                .frame(maxHeight: BrickUI.smallHeight)
-            }
+                    }
+                    
+                }))
         }
+        .frame(maxHeight: BrickUI.smallHeight)
     }
 }
 

--- a/OpenGluck/Bricks/AddInsulinBrick.swift
+++ b/OpenGluck/Bricks/AddInsulinBrick.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+import OG
+
+struct AddInsulinBrick: View {
+    @EnvironmentObject var appDelegate: PhoneAppDelegate
+    @EnvironmentObject var openGlückConnection: OpenGluckConnection
+    private var sheetStatusOptions: SheetStatusViewOptions { appDelegate.sheetStatusOptions }
+    
+    private func quickAddInsulin(units: Int) async throws {
+        guard let client = openGlückConnection.getClient() else {
+            fatalError("No client")
+        }
+        let insulinRecords: [OpenGluckInsulinRecord] = [
+            OpenGluckInsulinRecord(id: UUID(), timestamp: Date(), units: units, deleted: false)
+        ]
+        _ = try await client.upload(insulinRecords: insulinRecords)
+    }
+
+    @State var label: String = "Add"
+    var body: some View {
+        Grid {
+            GridRow {
+                Brick(title: "Insulin", systemImage: "cross.vial") {
+                    HoldButton(label: "Add")
+                    .contextMenu(ContextMenu(menuItems: {
+                        ForEach(1...16, id: \.self) { n in
+                            Button("\(n) IU") {
+                                sheetStatusOptions.state = SheetStatusViewState.inProgress
+                                sheetStatusOptions.status = "\(n) IU"
+                                sheetStatusOptions.subStatus1 = "Launching Task…"
+                                Task {
+                                    defer { sheetStatusOptions.state = SheetStatusViewState.complete }
+                                    sheetStatusOptions.subStatus1 = "Adding…"
+                                    do {
+                                        try await quickAddInsulin(units: n)
+                                        sheetStatusOptions.subStatus1 = "Done!"
+                                        NotificationCenter.default.post(name: Notification.Name.refreshOpenGlück, object: nil)
+                                    } catch {
+                                        sheetStatusOptions.pushError(message: error.localizedDescription)
+                                    }
+                                }
+                            }
+                        }
+                        
+                    }))
+                }
+                .frame(maxHeight: BrickUI.smallHeight)
+            }
+        }
+    }
+}
+
+#Preview("AddInsulinBrick") {
+    AddInsulinBrick()
+        .preferredColorScheme(.dark)
+}

--- a/OpenGluck/Bricks/Brick.swift
+++ b/OpenGluck/Bricks/Brick.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+
+struct BrickUI {
+    static let cornerRadius = 10.0
+    static let smallHeight: Double = 150.0
+}
+
+struct Brick<Content: View>: View {
+    let title: String
+    let systemImage: String?
+    @ViewBuilder let content: () -> Content
+    
+#if os(watchOS) || os(tvOS)
+    let secondarySystemGroupedBackground: Color = Color(red: 28/256, green: 28/256, blue: 30/256)
+#else
+    let secondarySystemGroupedBackground: Color = Color(uiColor: .secondarySystemGroupedBackground)
+#endif
+    
+    init(title: String, systemImage: String? = nil, @ViewBuilder content: @escaping () -> Content) {
+        self.title = title
+        self.systemImage = systemImage
+        self.content = content
+    }
+    
+    var body: some View {
+#if os(watchOS)
+        VStack {
+            content()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+#else
+        VStack {
+            HStack {
+                if let systemImage {
+                    Label(title, systemImage: systemImage)
+                        .font(.headline)
+                        .padding()
+                } else {
+                    Text(title)
+                        .font(.headline)
+                        .padding()
+                }
+            }
+            .foregroundStyle(Color(uiColor: .lightGray))
+            Spacer()
+            content()
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(secondarySystemGroupedBackground)
+        .clipShape(RoundedRectangle(cornerRadius: BrickUI.cornerRadius))
+#endif
+    }
+}
+
+#Preview("Brick") {
+    Grid {
+        GridRow {
+            Brick(title: "Alice") {
+                Text("Foo")
+            }
+        }
+    }
+    .preferredColorScheme(.dark)
+}
+

--- a/OpenGluck/Bricks/CurrentGlucoseBrick.swift
+++ b/OpenGluck/Bricks/CurrentGlucoseBrick.swift
@@ -5,26 +5,9 @@ struct CurrentGlucoseBrick: View {
     let now: Date
     @EnvironmentObject var openGlückEnvironment: OpenGluckEnvironment
 
-    @ViewBuilder var current: some View {
-        if let currentGlucoseRecord = openGlückEnvironment.currentGlucoseRecord {
-#if os(tvOS)
-            GlucoseView(
-                glucoseRecord: .constant(currentGlucoseRecord),
-                hasCgmRealTimeData: .constant(openGlückEnvironment.cgmHasRealTimeData),
-                font: .system(size: 35),
-                captionFont: .system(size: 15),
-                mode: .coloredBackground
-            )
-#else
-            let freshnessLevel = 1.0 - (-currentGlucoseRecord.timestamp.timeIntervalSince(now) / TimeInterval(10 * 60))
-            CurrentDataGauge(timestamp: .constant(currentGlucoseRecord.timestamp), mgDl: .constant(currentGlucoseRecord.mgDl), hasCgmRealTimeData: .constant(openGlückEnvironment.cgmHasRealTimeData), episode: .constant(nil), episodeTimestamp: .constant(nil), freshnessLevel: .constant(freshnessLevel))
-#endif
-        }
-    }
-    
     var body: some View {
         Brick(title: "Current") {
-            current
+            CurrentGlucose(now: now)
         }
         .frame(maxHeight: BrickUI.smallHeight)
     }

--- a/OpenGluck/Bricks/CurrentGlucoseBrick.swift
+++ b/OpenGluck/Bricks/CurrentGlucoseBrick.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+import OG
+
+struct CurrentGlucoseBrick: View {
+    let now: Date
+    @EnvironmentObject var openGlückEnvironment: OpenGluckEnvironment
+
+    @ViewBuilder var current: some View {
+        if let currentGlucoseRecord = openGlückEnvironment.currentGlucoseRecord {
+#if os(tvOS)
+            GlucoseView(
+                glucoseRecord: .constant(currentGlucoseRecord),
+                hasCgmRealTimeData: .constant(openGlückEnvironment.cgmHasRealTimeData),
+                font: .system(size: 35),
+                captionFont: .system(size: 15),
+                mode: .coloredBackground
+            )
+#else
+            let freshnessLevel = 1.0 - (-currentGlucoseRecord.timestamp.timeIntervalSince(now) / TimeInterval(10 * 60))
+            CurrentDataGauge(timestamp: .constant(currentGlucoseRecord.timestamp), mgDl: .constant(currentGlucoseRecord.mgDl), hasCgmRealTimeData: .constant(openGlückEnvironment.cgmHasRealTimeData), episode: .constant(nil), episodeTimestamp: .constant(nil), freshnessLevel: .constant(freshnessLevel))
+#endif
+        }
+    }
+    
+    var body: some View {
+        Brick(title: "Current") {
+            current
+        }
+        .frame(maxHeight: BrickUI.smallHeight)
+    }
+}
+
+#Preview("TrendBrick") {
+    Grid {
+        GridRow {
+            GlucoseTrendBrick(graphGeometry: CGSize(width: 300, height: 200))
+        }
+    }
+        .preferredColorScheme(.dark)
+}

--- a/OpenGluck/Bricks/GlucoseTrendBrick.swift
+++ b/OpenGluck/Bricks/GlucoseTrendBrick.swift
@@ -3,41 +3,10 @@ import OG
 
 struct GlucoseTrendBrick: View {
     let graphGeometry: CGSize?
-    @EnvironmentObject var openGlückEnvironment: OpenGluckEnvironment
 
     var body: some View {
         Brick(title: "Trend") {
-            if let lastHistoricGlucoseRecord = openGlückEnvironment.lastHistoricGlucoseRecord {
-                HStack(spacing: 0) {
-                    Spacer()
-                    GlucoseView(
-                        glucoseRecord: .constant(lastHistoricGlucoseRecord),
-                        hasCgmRealTimeData: .constant(openGlückEnvironment.cgmHasRealTimeData),
-                        font: .system(size: 16),
-                        captionFont: .system(size: 10),
-                        mode: .vibrantAgo
-                    )
-                    Spacer()
-                        .frame(maxWidth: 20.0)
-                    if let graphGeometry, let lastGlucoseRecords = openGlückEnvironment.lastGlucoseRecords, let lastGlucoseRecord = lastGlucoseRecords.sorted(by: { $0.timestamp > $1.timestamp }).first {
-                        // make an educated guess of the slope, assume max=350,
-                        // and width~5hrs
-                        // and fill entire width
-                        // angle=90 is all the way down,
-                        // angle=-90 is all the way up
-                        let elapsed: Double = lastGlucoseRecord.timestamp.timeIntervalSince(lastHistoricGlucoseRecord.timestamp)
-                        let deltaMgDl: Double = Double(lastGlucoseRecord.mgDl - lastHistoricGlucoseRecord.mgDl)
-                        let deltaFullWidth: Double = (3600.0*5) * deltaMgDl / elapsed
-                        let angleRaw = -(45 * graphGeometry.height / graphGeometry.width) / 350.0 * deltaFullWidth
-                        let angle: Double = max(min(angleRaw, 90), -90)
-                        Image(systemName: "arrow.right")
-                            .rotationEffect(.degrees(angle))
-                            .scaleEffect(2)
-                            .opacity(0.8)
-                        Spacer()
-                    }
-                }
-            }
+            GlucoseTrend(graphGeometry: graphGeometry)
         }
         .frame(maxHeight: BrickUI.smallHeight)
 

--- a/OpenGluck/Bricks/GlucoseTrendBrick.swift
+++ b/OpenGluck/Bricks/GlucoseTrendBrick.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+import OG
+
+struct GlucoseTrendBrick: View {
+    let graphGeometry: CGSize?
+    @EnvironmentObject var openGlückEnvironment: OpenGluckEnvironment
+
+    var body: some View {
+        Brick(title: "Trend") {
+            if let lastHistoricGlucoseRecord = openGlückEnvironment.lastHistoricGlucoseRecord {
+                HStack(spacing: 0) {
+                    Spacer()
+                    GlucoseView(
+                        glucoseRecord: .constant(lastHistoricGlucoseRecord),
+                        hasCgmRealTimeData: .constant(openGlückEnvironment.cgmHasRealTimeData),
+                        font: .system(size: 16),
+                        captionFont: .system(size: 10),
+                        mode: .vibrantAgo
+                    )
+                    Spacer()
+                        .frame(maxWidth: 20.0)
+                    if let graphGeometry, let lastGlucoseRecords = openGlückEnvironment.lastGlucoseRecords, let lastGlucoseRecord = lastGlucoseRecords.sorted(by: { $0.timestamp > $1.timestamp }).first {
+                        // make an educated guess of the slope, assume max=350,
+                        // and width~5hrs
+                        // and fill entire width
+                        // angle=90 is all the way down,
+                        // angle=-90 is all the way up
+                        let elapsed: Double = lastGlucoseRecord.timestamp.timeIntervalSince(lastHistoricGlucoseRecord.timestamp)
+                        let deltaMgDl: Double = Double(lastGlucoseRecord.mgDl - lastHistoricGlucoseRecord.mgDl)
+                        let deltaFullWidth: Double = (3600.0*5) * deltaMgDl / elapsed
+                        let angleRaw = -(45 * graphGeometry.height / graphGeometry.width) / 350.0 * deltaFullWidth
+                        let angle: Double = max(min(angleRaw, 90), -90)
+                        Image(systemName: "arrow.right")
+                            .rotationEffect(.degrees(angle))
+                            .scaleEffect(2)
+                            .opacity(0.8)
+                        Spacer()
+                    }
+                }
+            }
+        }
+        .frame(maxHeight: BrickUI.smallHeight)
+
+    }
+}
+
+#Preview("TrendBrick") {
+    Grid {
+        GridRow {
+            GlucoseTrendBrick(graphGeometry: CGSize(width: 300, height: 200))
+        }
+    }
+        .preferredColorScheme(.dark)
+}

--- a/OpenGluck/OpenGluck/OpenGluckEnvironmentUpdater.swift
+++ b/OpenGluck/OpenGluck/OpenGluckEnvironmentUpdater.swift
@@ -34,6 +34,11 @@ class OpenGluckEnvironment: ObservableObject
     }
 }
 
+extension Notification.Name {
+    static let refreshOpenGlück = Notification.Name("OpenGluckEnvironmentUpdater.refreshOpenGlück")
+}
+
+
 struct OpenGluckEnvironmentUpdater<Content>: View where Content: View {
     @ViewBuilder
     let content: () -> Content
@@ -90,7 +95,6 @@ struct OpenGluckEnvironmentUpdater<Content>: View where Content: View {
         if runRefresh {
             refresh()
         }
-
     }
         
     var body: some View {
@@ -118,6 +122,10 @@ struct OpenGluckEnvironmentUpdater<Content>: View where Content: View {
             }
             .onAppear {
                 refreshUnlessStartedRecently()
+            }
+            .onReceive(NotificationCenter.default.publisher(for: Notification.Name.refreshOpenGlück)) { _ in
+                print("Notification.Name.refreshOpenGlück")
+                refresh()
             }
 #if os(iOS)
             .onReceive(NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)) { _ in

--- a/OpenGluck/Records/Glucose/CurrentGlucose.swift
+++ b/OpenGluck/Records/Glucose/CurrentGlucose.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+struct CurrentGlucose: View {
+    @EnvironmentObject var openGlückEnvironment: OpenGluckEnvironment
+    let now: Date
+
+    var body: some View {
+        if let currentGlucoseRecord = openGlückEnvironment.currentGlucoseRecord {
+#if os(tvOS)
+            GlucoseView(
+                glucoseRecord: .constant(currentGlucoseRecord),
+                hasCgmRealTimeData: .constant(openGlückEnvironment.cgmHasRealTimeData),
+                font: .system(size: 35),
+                captionFont: .system(size: 15),
+                mode: .coloredBackground
+            )
+#else
+            let freshnessLevel = 1.0 - (-currentGlucoseRecord.timestamp.timeIntervalSince(now) / TimeInterval(10 * 60))
+            CurrentDataGauge(timestamp: .constant(currentGlucoseRecord.timestamp), mgDl: .constant(currentGlucoseRecord.mgDl), hasCgmRealTimeData: .constant(openGlückEnvironment.cgmHasRealTimeData), episode: .constant(nil), episodeTimestamp: .constant(nil), freshnessLevel: .constant(freshnessLevel))
+#endif
+        }
+    }
+}

--- a/OpenGluck/Records/Glucose/CurrentGlucoseView.swift
+++ b/OpenGluck/Records/Glucose/CurrentGlucoseView.swift
@@ -6,41 +6,6 @@ fileprivate struct CurrentGlucoseViewUI {
     static let cornerRadius = 10.0
 }
 
-fileprivate struct GridItem<Content: View>: View {
-    let title: String
-    @ViewBuilder let content: () -> Content
-    
-    #if os(watchOS) || os(tvOS)
-    let secondarySystemGroupedBackground: Color = Color(red: 28/256, green: 28/256, blue: 30/256)
-    #else
-    let secondarySystemGroupedBackground: Color = Color(uiColor: .secondarySystemGroupedBackground)
-    #endif
-    
-    var body: some View {
-        #if os(watchOS)
-        VStack {
-            content()
-        }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-        #else
-        VStack {
-            HStack {
-                Text(title)
-                    .font(.headline)
-                    .padding()
-            }
-            .foregroundStyle(Color(uiColor: .lightGray))
-            Spacer()
-            content()
-            Spacer()
-        }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(secondarySystemGroupedBackground)
-            .clipShape(RoundedRectangle(cornerRadius: CurrentGlucoseViewUI.cornerRadius))
-        #endif
-    }
-}
-
 struct CurrentGlucoseView: View {
     @EnvironmentObject var openGlückEnvironment: OpenGluckEnvironment
     
@@ -116,7 +81,7 @@ struct CurrentGlucoseView: View {
                 GridRow {
                     Grid {
                         GridRow {
-                            GridItem(title: "Trend") {
+                            Brick(title: "Trend") {
                                 if let lastHistoricGlucoseRecord = openGlückEnvironment.lastHistoricGlucoseRecord {
                                     HStack(spacing: 0) {
                                         Spacer()
@@ -149,12 +114,12 @@ struct CurrentGlucoseView: View {
                                     }
                                 }
                             }
-                            GridItem(title: "Current") {
+                            Brick(title: "Current") {
                                 current
                             }
                         }
                     }
-                    .frame(maxHeight: 150)
+                    .frame(maxHeight: BrickUI.smallHeight)
                 }
             }
         }

--- a/OpenGluck/Records/Glucose/CurrentGlucoseView.swift
+++ b/OpenGluck/Records/Glucose/CurrentGlucoseView.swift
@@ -12,12 +12,11 @@ struct CurrentGlucoseView: View {
     let now: Date
     enum Mode {
         case graph
-        case current
-        case full
+        case graphBrick
     }
     
-    var mode: Mode = .full
-    @State var graphGeometry: CGSize?
+    var mode: Mode = .graph
+    @Binding var graphGeometry: CGSize?
     
     @ViewBuilder var graph: some View {
         if let lastGlucoseRecords = openGlückEnvironment.lastGlucoseRecords, let lastInsulinRecords = openGlückEnvironment.lastInsulinRecords, let lastLowRecords = openGlückEnvironment.lastLowRecords {
@@ -46,82 +45,16 @@ struct CurrentGlucoseView: View {
         }
     }
     
-    @ViewBuilder var current: some View {
-        if let currentGlucoseRecord = openGlückEnvironment.currentGlucoseRecord {
-#if os(tvOS)
-            GlucoseView(
-                glucoseRecord: .constant(currentGlucoseRecord),
-                hasCgmRealTimeData: .constant(openGlückEnvironment.cgmHasRealTimeData),
-                font: .system(size: 35),
-                captionFont: .system(size: 15),
-                mode: .coloredBackground
-            )
-#else
-            let freshnessLevel = 1.0 - (-currentGlucoseRecord.timestamp.timeIntervalSince(now) / TimeInterval(10 * 60))
-            CurrentDataGauge(timestamp: .constant(currentGlucoseRecord.timestamp), mgDl: .constant(currentGlucoseRecord.mgDl), hasCgmRealTimeData: .constant(openGlückEnvironment.cgmHasRealTimeData), episode: .constant(nil), episodeTimestamp: .constant(nil), freshnessLevel: .constant(freshnessLevel))
-#endif
-        }
-    }
-    
     var body: some View {
         switch mode {
         case .graph:
             graph
-        case .current:
-            current
-        case .full:
-            Grid {
-                GridRow {
-                    graph
-                        .frame(maxHeight: 200)
-                    #if !os(watchOS)
-                        .clipShape(RoundedRectangle(cornerRadius: CurrentGlucoseViewUI.cornerRadius))
-                    #endif
-                }
-                GridRow {
-                    Grid {
-                        GridRow {
-                            Brick(title: "Trend") {
-                                if let lastHistoricGlucoseRecord = openGlückEnvironment.lastHistoricGlucoseRecord {
-                                    HStack(spacing: 0) {
-                                        Spacer()
-                                        GlucoseView(
-                                            glucoseRecord: .constant(lastHistoricGlucoseRecord),
-                                            hasCgmRealTimeData: .constant(openGlückEnvironment.cgmHasRealTimeData),
-                                            font: .system(size: 16),
-                                            captionFont: .system(size: 10),
-                                            mode: .vibrantAgo
-                                        )
-                                        Spacer()
-                                            .frame(maxWidth: 20.0)
-                                        if let graphGeometry, let lastGlucoseRecords = openGlückEnvironment.lastGlucoseRecords, let lastGlucoseRecord = lastGlucoseRecords.sorted(by: { $0.timestamp > $1.timestamp }).first {
-                                            // make an educated guess of the slope, assume max=350,
-                                            // and width~5hrs
-                                            // and fill entire width
-                                            // angle=90 is all the way down,
-                                            // angle=-90 is all the way up
-                                            let elapsed: Double = lastGlucoseRecord.timestamp.timeIntervalSince(lastHistoricGlucoseRecord.timestamp)
-                                            let deltaMgDl: Double = Double(lastGlucoseRecord.mgDl - lastHistoricGlucoseRecord.mgDl)
-                                            let deltaFullWidth: Double = (3600.0*5) * deltaMgDl / elapsed
-                                            let angleRaw = -(45 * graphGeometry.height / graphGeometry.width) / 350.0 * deltaFullWidth
-                                            let angle: Double = max(min(angleRaw, 90), -90)
-                                            Image(systemName: "arrow.right")
-                                                .rotationEffect(.degrees(angle))
-                                                .scaleEffect(2)
-                                                .opacity(0.8)
-                                            Spacer()
-                                        }
-                                    }
-                                }
-                            }
-                            Brick(title: "Current") {
-                                current
-                            }
-                        }
-                    }
-                    .frame(maxHeight: BrickUI.smallHeight)
-                }
-            }
+        case .graphBrick:
+            graph
+                .frame(maxHeight: 200)
+#if !os(watchOS)
+                .clipShape(RoundedRectangle(cornerRadius: CurrentGlucoseViewUI.cornerRadius))
+#endif
         }
     }
 }
@@ -129,7 +62,12 @@ struct CurrentGlucoseView: View {
 struct CurrentGlucoseView_Previews: PreviewProvider {
     static var previews: some View {
         OpenGluckEnvironmentUpdater {
-            CurrentGlucoseView(now: Date())
+            Grid {
+                GridRow {
+                    CurrentGlucoseView(now: Date(), mode: .graphBrick, graphGeometry: .constant(CGSize(width: 0, height: 0)))
+                        .gridCellColumns(2)
+                }
+            }
         }
         .environmentObject(OpenGluckConnection())
     }

--- a/OpenGluck/Records/Glucose/GlucoseTrend.swift
+++ b/OpenGluck/Records/Glucose/GlucoseTrend.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+struct GlucoseTrend: View {
+    let graphGeometry: CGSize?
+    @EnvironmentObject var openGlückEnvironment: OpenGluckEnvironment
+
+    var body: some View {
+        Group {
+            if let lastHistoricGlucoseRecord = openGlückEnvironment.lastHistoricGlucoseRecord {
+                HStack(spacing: 0) {
+                    Spacer()
+                    GlucoseView(
+                        glucoseRecord: .constant(lastHistoricGlucoseRecord),
+                        hasCgmRealTimeData: .constant(openGlückEnvironment.cgmHasRealTimeData),
+                        font: .system(size: 16),
+                        captionFont: .system(size: 10),
+                        mode: .vibrantAgo
+                    )
+                    Spacer()
+                        .frame(maxWidth: 20.0)
+                    if let graphGeometry, let lastGlucoseRecords = openGlückEnvironment.lastGlucoseRecords, let lastGlucoseRecord = lastGlucoseRecords.sorted(by: { $0.timestamp > $1.timestamp }).first {
+                        // make an educated guess of the slope, assume max=350,
+                        // and width~5hrs
+                        // and fill entire width
+                        // angle=90 is all the way down,
+                        // angle=-90 is all the way up
+                        let elapsed: Double = lastGlucoseRecord.timestamp.timeIntervalSince(lastHistoricGlucoseRecord.timestamp)
+                        let deltaMgDl: Double = Double(lastGlucoseRecord.mgDl - lastHistoricGlucoseRecord.mgDl)
+                        let deltaFullWidth: Double = (3600.0*5) * deltaMgDl / elapsed
+                        let angleRaw = -(45 * graphGeometry.height / graphGeometry.width) / 350.0 * deltaFullWidth
+                        let angle: Double = max(min(angleRaw, 90), -90)
+                        Image(systemName: "arrow.right")
+                            .rotationEffect(.degrees(angle))
+                            .scaleEffect(2)
+                            .opacity(0.8)
+                        Spacer()
+                    }
+                }
+            }
+        }
+        .frame(maxHeight: BrickUI.smallHeight)
+
+    }
+}

--- a/OpenGluck/Records/Glucose/LastRecordsView.swift
+++ b/OpenGluck/Records/Glucose/LastRecordsView.swift
@@ -100,30 +100,28 @@ struct LastRecordsView: View {
     #endif
 
     var body: some View {
-        List {
-            ForEach(Array(records), id: \.id) { record in
-                switch record {
-                case .glucose(_, glucoseRecord: let glucoseRecord):
-                    GlucoseRecordView(glucoseRecord: .constant(glucoseRecord))
-                        .deleteDisabled(true)
-                case .insulin(_, insulinRecord: let insulinRecord):
-                    InsulinRecordView(insulinRecord: .constant(insulinRecord))
-                case .low(_, lowRecord: let lowRecord):
-                    LowRecordView(lowRecord: .constant(lowRecord))
-                        .deleteDisabled(true)
-                }
+        ForEach(Array(records), id: \.id) { record in
+            switch record {
+            case .glucose(_, glucoseRecord: let glucoseRecord):
+                GlucoseRecordView(glucoseRecord: .constant(glucoseRecord))
+                    .deleteDisabled(true)
+            case .insulin(_, insulinRecord: let insulinRecord):
+                InsulinRecordView(insulinRecord: .constant(insulinRecord))
+            case .low(_, lowRecord: let lowRecord):
+                LowRecordView(lowRecord: .constant(lowRecord))
+                    .deleteDisabled(true)
             }
-#if os(iOS)
-            .onDelete(perform: { indexSet in
-                let recordsToDelete: [Record] = indexSet.map { records[$0] }
-                recordsToDelete.forEach { record in
-                    hiddenIds.insert(record.id)
-                    deleteRecord(record)
-                }
-            })
-#endif
         }
-        .task(id: UUID()) {
+#if os(iOS)
+        .onDelete(perform: { indexSet in
+            let recordsToDelete: [Record] = indexSet.map { records[$0] }
+            recordsToDelete.forEach { record in
+                hiddenIds.insert(record.id)
+                deleteRecord(record)
+            }
+        })
+#endif
+        .onReceive(openGlückUpdater.$revision) { _ in
             withAnimation {
                 update()
             }
@@ -134,9 +132,7 @@ struct LastRecordsView: View {
 struct LastRecordsView_Previews: PreviewProvider {
     static var previews: some View {
         OpenGluckEnvironmentUpdater {
-            List {
-                LastRecordsView()
-            }
+            LastRecordsView()
         }
             .environmentObject(OpenGluckConnection())
     }

--- a/OpenGluck/Records/Glucose/LastRecordsView.swift
+++ b/OpenGluck/Records/Glucose/LastRecordsView.swift
@@ -1,11 +1,132 @@
 import SwiftUI
+import OG
 
 struct LastRecordsView: View {
     @EnvironmentObject var openGlückUpdater: OpenGluckEnvironment
+    @EnvironmentObject var openGlückConnection: OpenGluckConnection
+    #if os(iOS)
+    @EnvironmentObject var appDelegate: PhoneAppDelegate
+    private var sheetStatusOptions: SheetStatusViewOptions { appDelegate.sheetStatusOptions }
+    #endif
+
+    enum Record: Hashable, Identifiable {
+        case glucose(id: UUID, glucoseRecord: OpenGluckGlucoseRecord)
+        case insulin(id: UUID, insulinRecord: OpenGluckInsulinRecord)
+        case low(id: UUID, lowRecord: OpenGluckLowRecord)
+        
+        var id: UUID {
+            switch self {
+            case .glucose(id: let id, _): id
+            case .insulin(id: _, let insulinRecord): insulinRecord.id
+            case .low(id: _, let lowRecord): lowRecord.id
+            }
+        }
+        
+        var timestamp: Date {
+            switch self {
+            case .glucose(_, glucoseRecord: let glucoseRecord): glucoseRecord.timestamp
+            case .insulin(_, insulinRecord: let insulinRecord): insulinRecord.timestamp
+            case .low(_, lowRecord: let lowRecord): lowRecord.timestamp
+            }
+        }
+        
+        func hash(into hasher: inout Hasher) {
+            switch self {
+            case .glucose(_, glucoseRecord: let glucoseRecord): glucoseRecord.hash(into: &hasher)
+            case .insulin(_, insulinRecord: let insulinRecord): insulinRecord.hash(into: &hasher)
+            case .low(_, lowRecord: let lowRecord): lowRecord.hash(into: &hasher)
+            }
+        }
+    }
+    
+    @State var records: [Record] = []
+    @State var hiddenIds: Set<UUID> = Set()
+    
+    private func update() {
+        var result: [Record] = []
+        for insulinRecord in openGlückUpdater.lastInsulinRecords ?? [] {
+            if !insulinRecord.deleted {
+                result.append(Record.insulin(id: UUID(), insulinRecord: insulinRecord))
+            }
+        }
+        for glucoseRecord in openGlückUpdater.lastGlucoseRecords ?? [] {
+            result.append(Record.glucose(id: UUID(), glucoseRecord: glucoseRecord))
+        }
+        for lowRecord in openGlückUpdater.lastLowRecords ?? [] {
+            if !lowRecord.deleted {
+                result.append(Record.low(id: UUID(), lowRecord: lowRecord))
+            }
+        }
+        records = result
+            .sorted(by: { $0.timestamp > $1.timestamp })
+            .filter { !hiddenIds.contains($0.id) }
+    }
+    
+    #if os(iOS)
+    private func deleteRecord(_ record: Record) {
+        sheetStatusOptions.state = SheetStatusViewState.inProgress
+        sheetStatusOptions.status = "Deleting…"
+        sheetStatusOptions.subStatus1 = "Launching Task…"
+        Task {
+            sheetStatusOptions.subStatus1 = "Deleting…"
+            defer { sheetStatusOptions.state = SheetStatusViewState.complete }
+
+            do {
+                switch record {
+                case .glucose(glucoseRecord: _): fatalError("Don't know how to delete glucose record")
+                case .low(lowRecord: _): fatalError("Don't know how to delete low record")
+                case .insulin(_, insulinRecord: let insulinRecord): try await deleteInsulinRecord(insulinRecord)
+                }
+                
+                sheetStatusOptions.subStatus1 = "Done!"
+                NotificationCenter.default.post(name: Notification.Name.refreshOpenGlück, object: nil)
+            } catch {
+                hiddenIds = Set()
+                sheetStatusOptions.pushError(message: error.localizedDescription)
+            }
+        }
+    }
+    
+    private func deleteInsulinRecord(_ insulinRecord: OpenGluckInsulinRecord) async throws {
+        print("TODO delete \(insulinRecord.units)")
+        guard let client = openGlückConnection.getClient() else {
+            fatalError("No client")
+        }
+        let insulinRecords: [OpenGluckInsulinRecord] = [
+            OpenGluckInsulinRecord(id: insulinRecord.id, timestamp: insulinRecord.timestamp, units: insulinRecord.units, deleted: true)
+        ]
+        _ = try await client.upload(insulinRecords: insulinRecords)
+    }
+    #endif
 
     var body: some View {
-        ForEach(openGlückUpdater.lastGlucoseRecords ?? [], id: \.self) { glucoseRecord in
-            GlucoseRecordView(glucoseRecord: .constant(glucoseRecord))
+        List {
+            ForEach(Array(records), id: \.id) { record in
+                switch record {
+                case .glucose(_, glucoseRecord: let glucoseRecord):
+                    GlucoseRecordView(glucoseRecord: .constant(glucoseRecord))
+                        .deleteDisabled(true)
+                case .insulin(_, insulinRecord: let insulinRecord):
+                    InsulinRecordView(insulinRecord: .constant(insulinRecord))
+                case .low(_, lowRecord: let lowRecord):
+                    LowRecordView(lowRecord: .constant(lowRecord))
+                        .deleteDisabled(true)
+                }
+            }
+#if os(iOS)
+            .onDelete(perform: { indexSet in
+                let recordsToDelete: [Record] = indexSet.map { records[$0] }
+                recordsToDelete.forEach { record in
+                    hiddenIds.insert(record.id)
+                    deleteRecord(record)
+                }
+            })
+#endif
+        }
+        .task(id: UUID()) {
+            withAnimation {
+                update()
+            }
         }
     }
 }

--- a/OpenGluck/Records/Insulin/InsulinRecordView.swift
+++ b/OpenGluck/Records/Insulin/InsulinRecordView.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+import OG
+import OGUI
+
+struct InsulinRecordView: View {
+    @Binding var insulinRecord: OpenGluckInsulinRecord
+
+    var body: some View {
+        HStack {
+            InsulinUnit(units: insulinRecord.units)
+            Spacer()
+            TimestampView(mode: .minutesToText, timestamp: .constant(insulinRecord.timestamp))
+        }
+        .foregroundColor(InsulinUnit.foregroundColor(forTimestamp: insulinRecord.timestamp))
+    }
+}
+
+struct InsulinRecordView_Previews: PreviewProvider {
+    static var previews: some View {
+        InsulinRecordView(insulinRecord: .constant(OpenGluckInsulinRecord(id: UUID(), timestamp: Date().addingTimeInterval(-(42+60)*60), units: 1, deleted: false)))
+            .previewDisplayName("1")
+        InsulinRecordView(insulinRecord: .constant(OpenGluckInsulinRecord(id: UUID(), timestamp: Date().addingTimeInterval(-42*60), units: 2, deleted: false)))
+            .previewDisplayName("2")
+        InsulinRecordView(insulinRecord: .constant(OpenGluckInsulinRecord(id: UUID(), timestamp: Date().addingTimeInterval(-42*60), units: 3, deleted: false)))
+            .previewDisplayName("3")
+        InsulinRecordView(insulinRecord: .constant(OpenGluckInsulinRecord(id: UUID(), timestamp: Date().addingTimeInterval(-42*60), units: 10, deleted: false)))
+            .previewDisplayName("10")
+        InsulinRecordView(insulinRecord: .constant(OpenGluckInsulinRecord(id: UUID(), timestamp: Date().addingTimeInterval(-42*60), units: 20, deleted: false)))
+            .previewDisplayName("20")
+    }
+}

--- a/OpenGluck/Records/Low/LowRecordView.swift
+++ b/OpenGluck/Records/Low/LowRecordView.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+import OG
+import OGUI
+
+struct LowRecordView: View {
+    @Binding var lowRecord: OpenGluckLowRecord
+
+    var body: some View {
+        HStack {
+            SnackGram(sugarInGrams: lowRecord.sugarInGrams)
+            Spacer()
+            TimestampView(mode: .minutesToText, timestamp: .constant(lowRecord.timestamp))
+        }
+        .foregroundColor(SnackGram.foregroundColor(forTimestamp: lowRecord.timestamp))
+    }
+}
+
+struct LowRecordView_Previews: PreviewProvider {
+    static var previews: some View {
+        LowRecordView(lowRecord: .constant(OpenGluckLowRecord(id: UUID(), timestamp: Date().addingTimeInterval(-(42+60)*60), sugarInGrams: 1, deleted: false)))
+            .previewDisplayName("1")
+        LowRecordView(lowRecord: .constant(OpenGluckLowRecord(id: UUID(), timestamp: Date().addingTimeInterval(-42*60), sugarInGrams: 2, deleted: false)))
+            .previewDisplayName("2")
+        LowRecordView(lowRecord: .constant(OpenGluckLowRecord(id: UUID(), timestamp: Date().addingTimeInterval(-42*60), sugarInGrams: .pi, deleted: false)))
+            .previewDisplayName("3.14")
+        LowRecordView(lowRecord: .constant(OpenGluckLowRecord(id: UUID(), timestamp: Date().addingTimeInterval(-42*60), sugarInGrams: 10, deleted: false)))
+            .previewDisplayName("10")
+        LowRecordView(lowRecord: .constant(OpenGluckLowRecord(id: UUID(), timestamp: Date().addingTimeInterval(-42*60), sugarInGrams: 20, deleted: false)))
+            .previewDisplayName("20")
+    }
+}

--- a/OpenGluck/UI/HoldButton.swift
+++ b/OpenGluck/UI/HoldButton.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+struct HoldButton: View {
+    let label: String
+    @State var pleaseHold: Bool = false
+    @State var task: Task<Void,Error>? = nil
+    
+    private var labelLabel: String {
+        pleaseHold ? "Tap & Hold" : label
+    }
+    
+    private var labelSystemImage: String {
+        pleaseHold ? "hand.tap.fill" : "hand.tap"
+    }
+    
+    var body: some View {
+        VStack {
+            Label(labelLabel, systemImage: labelSystemImage)
+                .contentTransition(.numericText())
+                .padding()
+                .foregroundStyle(Color(uiColor: .lightGray))
+                .background(Color(uiColor: .systemFill))
+                .clipShape(Capsule())
+        }
+        .onTapGesture {
+            withAnimation {
+                pleaseHold = true
+            }
+            if let task { task.cancel() }
+            task = Task {
+                try? await Task.sleep(for: .seconds(2))
+                guard !Task.isCancelled else { return }
+                withAnimation {
+                    pleaseHold = false
+                }
+            }
+        }
+    }
+    
+    
+}

--- a/OpenGluck/UI/InsulinUnit.swift
+++ b/OpenGluck/UI/InsulinUnit.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+struct InsulinUnit: View {
+    let units: Int
+    
+    enum Style {
+        case short
+        case long
+    }
+    
+    static func localize(_ units: Int) -> String {
+        Self.localize(Double(units))
+    }
+    
+    static func localize(_ units: Double) -> String {
+        if abs(units - round(units)) < Double.ulpOfOne {
+            return "\(Int(round(units))) IU"
+        } else {
+            return "\(round(units * 10) / 10) IU"
+        }
+    }
+    
+    var body: some View {
+        Text(Self.localize(units))
+    }
+    
+    static func foregroundColor(forTimestamp timestamp: Date) -> Color? {
+        let elapsed = -timestamp.timeIntervalSinceNow
+        if elapsed < 30 * 60 {
+            return Color.orange
+        } else if elapsed < 60 * 60 {
+            return Color.red
+        } else {
+            return nil
+        }
+    }
+}
+

--- a/OpenGluck/UI/SheetStatusView.swift
+++ b/OpenGluck/UI/SheetStatusView.swift
@@ -1,0 +1,220 @@
+import SwiftUI
+
+enum SheetStatusViewState {
+    case inProgress
+    case complete
+}
+
+class SheetStatusViewOptions: ObservableObject {
+    struct Error {
+        let id: UUID
+        let message: String
+    }
+    
+    @Published var state: SheetStatusViewState?
+    @Published var status: String = ""
+    @Published var subStatus1: String = ""
+    @Published var subStatus2: String = ""
+    @Published var errors: [Error] = []
+    
+    @discardableResult
+    func pushError(message: String) -> UUID {
+        let id = UUID()
+        let error = Error(id: id, message: message)
+        errors.append(error)
+        return id
+    }
+    
+    func cancelError(id: UUID) {
+        errors.removeAll { $0.id == id }
+    }
+}
+
+struct SheetStatusView: View {
+    @EnvironmentObject var options: SheetStatusViewOptions
+
+    @State private var status: String = ""
+    @State private var subStatus1: String = ""
+    @State private var subStatus2: String = ""
+
+    @State private var isPresented = false
+    @State private var scaling = false
+    @State private var scalingDone = false
+    @State private var page: Int = 1
+    @State private var errors: [SheetStatusViewOptions.Error] = []
+    
+    var body: some View {
+        VStack {
+        }
+        .onReceive(options.$errors, perform: { errors in
+            self.errors = errors
+        })
+        .sheet(isPresented: .constant(errors.count > 0)) {
+            GeometryReader(content: { geometry in
+                ScrollView {
+                    ForEach(errors.indices, id: \.self) { i in
+                        let error = errors[i]
+                        VStack {
+                            HStack {
+                                Image(systemName: "exclamationmark.bubble.fill")
+                                    .font(.title2)
+                                    .foregroundColor(.white)
+                                    .padding()
+                                Text(error.message)
+                                    .foregroundColor(.white)
+                                    .padding([.vertical, .trailing])
+                                Spacer()
+                            }
+                            if i < errors.count - 1 {
+                                Rectangle()
+                                    .frame(width: geometry.size.width, height: 1)
+                                    .foregroundColor(Color(uiColor: .systemBackground))
+                            }
+                        }
+                    }
+                }
+                .frame(width: geometry.size.width, height: geometry.size.width)
+                .background(.red)
+            })
+            .presentationDetents([.height(200)])
+            .presentationDragIndicator(.hidden)
+        }
+        .sheet(isPresented: .init(get: { isPresented && errors.count == 0 }, set: { isPresented = $0 })) {
+            VStack {
+                Spacer()
+                TabView(selection: $page) {
+                    VStack(spacing: 8) {
+                        Image(systemName: "plus.circle.fill")
+                            .scaleEffect(scaling ? 0.9 : 1)
+                            .font(.system(size: 40))
+                            .foregroundColor(Color(uiColor: .secondaryLabel))
+                            .onAppear {
+                                //LATER re-introduce animation, if they work
+                                //withAnimation(.spring().repeatForever()) {
+                                    scaling.toggle()
+                                //}
+                            }
+                        Text(status)
+                        Text(subStatus1)
+                            .font(.subheadline)
+                        Text(subStatus2)
+                            .font(.subheadline)
+                    }
+                    .tag(1)
+                    .contentShape(Rectangle()).gesture(DragGesture())
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 80))
+                        .scaleEffect(scalingDone ? 1 : 0.5)
+                        .foregroundColor(.white)
+                        .tag(2)
+                        .contentShape(Rectangle()).gesture(DragGesture())
+                }
+                
+                .tabViewStyle(.page(indexDisplayMode: .never))
+                Spacer()
+            }
+            .background(page == 1 ? Color(.systemBackground) : .green)
+            .presentationDetents([.height(200)])
+            .presentationDragIndicator(.hidden)
+        }
+        .onReceive(options.$status) { newStatus in
+            //withAnimation {
+                status = newStatus
+            //}
+            
+        }
+        .onReceive(options.$subStatus1) { newSubStatus1 in subStatus1 = newSubStatus1 }
+        .onReceive(options.$subStatus2) { newSubStatus2 in subStatus2 = newSubStatus2 }
+        .onReceive(options.$state) { newState in
+            guard let newState else {
+                isPresented = false
+                return
+            }
+            switch newState {
+            case .inProgress:
+                page = 1
+                scalingDone = false
+                isPresented = true
+            case .complete:
+                Task {
+                    withAnimation {
+                        page = 2
+                    }
+                    let animationInterval: TimeInterval = 0.3
+                    try? await Task.sleep(for: .seconds(animationInterval / 3))
+                    //withAnimation(.easeIn(duration: animationInterval)) {
+                        scalingDone = true
+                    //}
+                    try? await Task.sleep(for: .seconds(animationInterval))
+                    //withAnimation(.spring()) {
+                        scalingDone = false
+                    //}
+                    try? await Task.sleep(for: .seconds(animationInterval / 3))
+                    print("isPresented = false")
+                    isPresented = false
+                }
+            }
+        }
+    }
+}
+
+struct SheetStatusView_Previews: PreviewProvider {
+    @MainActor
+    struct Preview: View {
+        @State var options = SheetStatusViewOptions()
+        
+        func run() {
+            options.state = .inProgress
+            options.subStatus1 = "Substatus One"
+            options.subStatus2 = "Substatus Two"
+            Task {
+                options.status = "Status A1"
+                try? await Task.sleep(for: .seconds(0.5))
+                options.status = "Status B2"
+                try? await Task.sleep(for: .seconds(1.5))
+                options.state = .complete
+            }
+        }
+        
+        var body: some View {
+            VStack {
+                SheetStatusView()
+                    .environmentObject(options)
+                Button("Run") {
+                    run()
+                }
+            }
+        }
+    }
+    
+    struct ErrorPreview: View {
+        @State var options = SheetStatusViewOptions()
+        
+        var body: some View {
+            VStack {
+                List {
+                    Button("Clear All") {
+                        options.errors = []
+                    }
+                    Button("Add Temporary") {
+                        Task {
+                            let id = options.pushError(message: "This is a temporary error scheduled at: \(Date()))")
+                            try? await Task.sleep(for: .seconds(2))
+                            options.cancelError(id: id)
+                        }
+                    }
+                }
+                SheetStatusView()
+                    .environmentObject(options)
+            }
+            .task {
+                options.pushError(message: "This is a test error. You can dismiss it by clicking Clear All in the view below.")
+            }
+        }
+    }
+    
+    static var previews: some View {
+        Preview()
+        ErrorPreview()
+    }
+}

--- a/OpenGluck/UI/SnackGram.swift
+++ b/OpenGluck/UI/SnackGram.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+import OGUI
+
+struct SnackGram: View {
+    let sugarInGrams: Double
+    
+    enum Style {
+        case short
+        case long
+    }
+    
+    static func localize(_ sugarInGrams: Int) -> String {
+        Self.localize(Double(sugarInGrams))
+    }
+    
+    static func localize(_ sugarInGrams: Double) -> String {
+        return "\(Int(round(sugarInGrams)))g"
+    }
+    
+    var body: some View {
+        Text(Self.localize(sugarInGrams))
+    }
+    
+    static func foregroundColor(forTimestamp timestamp: Date) -> Color? {
+        let elapsed = -timestamp.timeIntervalSinceNow
+        if elapsed < 30 * 60 {
+            return OGUI.lowColor
+        } else if elapsed < 60 * 60 {
+#if os(watchOS)
+            return Color.white
+#else
+            return Color(uiColor: .label)
+#endif
+        } else {
+#if os(watchOS)
+            return Color.gray
+#else
+            return Color(uiColor: .placeholderText)
+#endif
+        }
+    }
+}
+


### PR DESCRIPTION
This PR enhances the app with a new capability to add Insulin records units into OpenGlück.

This might be useful when you're looking at your blood glucose and decide to inject some units, using an offline device that won't register units to the OpenGlück Server.

![image](https://github.com/open-gluck/opengluck-swift-app/assets/66381046/f313ca26-9d25-41b3-abfb-196f550b4788)

### Good To Know

- This PR rewors somehow how we display items in the main tab, maybe later we can use it to implement “widgets”

