### PR TITLE
Add support for iOS 17.4

### DIFF
--- a/OpenGluck.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OpenGluck.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "74cbe2cf54bc057c18ff7166b60b2799fb7943f1d0980cd8a29a6e0c9e13c044",
   "pins" : [
     {
       "identity" : "og",

--- a/OpenGluck/AppIntents/AppsShortcuts.swift
+++ b/OpenGluck/AppIntents/AppsShortcuts.swift
@@ -22,6 +22,8 @@ struct AppsShortcuts: AppShortcutsProvider {
         AppShortcut(
             intent: AddInsulinAppIntent(),
             phrases: [
+                "\(.applicationName) insulin",
+                "\(.applicationName) add insulin",
                 "\(\.$unitsEnum) insulin units in \(.applicationName)",
                 "\(.applicationName) \(\.$unitsEnum) unit",
                 "\(.applicationName) \(\.$unitsEnum) units",
@@ -31,9 +33,11 @@ struct AppsShortcuts: AppShortcutsProvider {
             shortTitle: "Add insulin",
             systemImageName: "cross.vial"
         )
+
         AppShortcut(
             intent: AddLowAppIntent(),
             phrases: [
+                "\(.applicationName) sugar",
                 "\(\.$sugarInGramsEnum) grams of sugar in \(.applicationName)",
                 "\(.applicationName) \(\.$sugarInGramsEnum) gram",
                 "\(.applicationName) \(\.$sugarInGramsEnum) grams",

--- a/OpenGluck/AppIntents/InsulinUnitEnum.swift
+++ b/OpenGluck/AppIntents/InsulinUnitEnum.swift
@@ -70,7 +70,7 @@ enum InsulinUnitEnum: Int, AppEnum {
         .value29 : DisplayRepresentation(stringLiteral: "29"),
     ]
     
-    static var allCases: [InsulinUnitEnum] = (1...25).map { InsulinUnitEnum(rawValue: $0)! }
+    static var allCases: [InsulinUnitEnum] = (1...29).map { InsulinUnitEnum(rawValue: $0)! }
 }
 
 #if false

--- a/OpenGluck/AppIntents/InsulinUnitEnum.swift
+++ b/OpenGluck/AppIntents/InsulinUnitEnum.swift
@@ -2,6 +2,7 @@ import AppIntents
 
 /* 
  For some reasons Siri won't parse integers in intents but is glad to parse an enum, so here we go.
+ FIXME: seems this is broken in iOS 17.4 and watchOS 10.4 :/
  */
 
 enum InsulinUnitEnum: Int, AppEnum {
@@ -69,6 +70,40 @@ enum InsulinUnitEnum: Int, AppEnum {
         .value29 : DisplayRepresentation(stringLiteral: "29"),
     ]
     
-    static var allCases: [InsulinUnitEnum] = (1...29).map { InsulinUnitEnum(rawValue: $0)! }
+    static var allCases: [InsulinUnitEnum] = (1...25).map { InsulinUnitEnum(rawValue: $0)! }
 }
 
+#if false
+/// the same hack, with AppEntity
+/// doesn't work on watchOS 10.4
+
+struct InsulinAppEntity: Identifiable {
+    var id: String { "\(units)" }
+    let units: Int
+}
+
+extension InsulinAppEntity: AppEntity {
+    static var defaultQuery = InsulinAppEntityQuery()
+    static var typeDisplayRepresentation: TypeDisplayRepresentation = "Insulin units"
+    var displayRepresentation: DisplayRepresentation {
+        DisplayRepresentation(title: "\(units)")
+    }
+}
+
+struct InsulinAppEntityQuery: EntityQuery {
+    func entities(for identifiers: [String]) async throws -> [InsulinAppEntity] {
+        /// Filter all available groups using the given identifiers
+        try await suggestedEntities().filter { identifiers.contains($0.id) }
+    }
+    
+    func suggestedEntities() async throws -> [InsulinAppEntity] {
+        /// Return a list of suggested favorite groups to use
+        (1...25).map { InsulinAppEntity(units: $0) }
+    }
+    
+    func defaultResult() async -> InsulinAppEntity? {
+        /// Return default selected group
+        nil
+    }
+}
+#endif


### PR DESCRIPTION
- update XCode project to XCode 15.3
- add some new App Shortcuts phrase to workaround limitations by iOS 17.4 and watchOS 10.4 in understanding enums

It is unfortunate “App Shortcuts Preview” is missing in XCode 15.3. Makes it harder to understand what phrases are available.