### PR TITLE
feat: add trend line in glucose graph

### DIFF
--- a/OpenGluck/OpenGluck/OpenGluckUI.swift
+++ b/OpenGluck/OpenGluck/OpenGluckUI.swift
@@ -1,0 +1,8 @@
+//
+//  OpenGluckUI.swift
+//  OpenGluck
+//
+//  Created by Christopher on 26/05/2024.
+//
+
+import Foundation

--- a/OpenGluck/Records/Glucose/GlucoseGraph.swift
+++ b/OpenGluck/Records/Glucose/GlucoseGraph.swift
@@ -1089,7 +1089,7 @@ struct GlucoseGraph_Previews: PreviewProvider {
         }
     }
     
-    #if true
+    #if false
     // LATER FIXME can't show live previews on widget
     struct LivePreview: View {
         @EnvironmentObject var openGlückEnvironment: OpenGluckEnvironment
@@ -1126,7 +1126,7 @@ struct GlucoseGraph_Previews: PreviewProvider {
             .preferredColorScheme(.dark)
             .previewDisplayName("Empty Mock Data")
 
-#if true
+#if false
         // LATER FIXME can't show live previews on widget
         OpenGluckEnvironmentUpdater {
             LivePreview()

--- a/OpenGluck/Records/Glucose/GlucoseGraph.swift
+++ b/OpenGluck/Records/Glucose/GlucoseGraph.swift
@@ -524,13 +524,20 @@ struct GlucoseGraph: View {
                     .annotation(position: .overlay, alignment: .center, spacing: 0) {
                         ZStack {
                             if isLast, let angleLastToPreviousScanRecord, let trendLineLengthOnAXis {
+#if os(watchOS)
+                                let colorStart: Color =  .white.opacity(0.6)
+                                let colorEnd: Color = .white.opacity(0.05)
+#else
+                                let colorStart: Color = .white.opacity(0.3)
+                                let colorEnd: Color = .white.opacity(0)
+#endif
                                 Rectangle()
                                     .position(x: trendLineLengthOnAXis, y: 5)
                                     .rotationEffect(.radians(Double.pi + angleLastToPreviousScanRecord))
                                     .frame(width: trendLineLengthOnAXis, height: 10)
                                     .foregroundStyle(.linearGradient(colors: [
-                                        .white.opacity(0.3),
-                                        .white.opacity(0)
+                                        colorStart,
+                                        colorEnd
                                     ], startPoint: .leading, endPoint: .trailing))
                             }
                         }


### PR DESCRIPTION
Add subtle trend line in glucose graph

This takes the last two scan records to draw a “trend” (whatever this really means depending on the capacity of the sensor to report real trend in such a short time notice)

![Simulator Screenshot - iPhone 15 Pro - 2024-04-01 at 16 05 40](https://github.com/open-gluck/opengluck-swift-app/assets/66381046/55900507-bc03-4760-ba05-17fe6d1ea7a0)
