### PR TITLE
fix: app shortcuts phrases for better use with watchOS 10.4

### DIFF
--- a/OpenGluck/AppIntents/AppsShortcuts.swift
+++ b/OpenGluck/AppIntents/AppsShortcuts.swift
@@ -41,6 +41,8 @@ struct AppsShortcuts: AppShortcutsProvider {
             intent: AddLowAppIntent(),
             phrases: [
                 "\(.applicationName) record sugar",
+                "\(.applicationName) note sugar",
+                "\(.applicationName) add sugar",
                 "\(\.$sugarInGramsEnum) grams of sugar in \(.applicationName)",
                 "\(.applicationName) \(\.$sugarInGramsEnum) gram",
                 "\(.applicationName) \(\.$sugarInGramsEnum) grams",

--- a/OpenGluck/AppIntents/AppsShortcuts.swift
+++ b/OpenGluck/AppIntents/AppsShortcuts.swift
@@ -6,6 +6,7 @@ struct AppsShortcuts: AppShortcutsProvider {
         AppShortcut(
             intent: DeleteLastInsulinAppIntent(),
             phrases: [
+                "\(.applicationName) delete last insulin",
                 "Delete the last insulin in \(.applicationName)",
             ],
             shortTitle: "Delete Last Insulin",
@@ -14,6 +15,7 @@ struct AppsShortcuts: AppShortcutsProvider {
         AppShortcut(
             intent: DeleteLastLowAppIntent(),
             phrases: [
+                "\(.applicationName) delete last sugar",
                 "Delete the last sugar in \(.applicationName)",
             ],
             shortTitle: "Delete Last Sugar",
@@ -22,7 +24,8 @@ struct AppsShortcuts: AppShortcutsProvider {
         AppShortcut(
             intent: AddInsulinAppIntent(),
             phrases: [
-                "\(.applicationName) insulin",
+                "\(.applicationName) record insulin",
+                "\(.applicationName) note insulin",
                 "\(.applicationName) add insulin",
                 "\(\.$unitsEnum) insulin units in \(.applicationName)",
                 "\(.applicationName) \(\.$unitsEnum) unit",
@@ -37,7 +40,7 @@ struct AppsShortcuts: AppShortcutsProvider {
         AppShortcut(
             intent: AddLowAppIntent(),
             phrases: [
-                "\(.applicationName) sugar",
+                "\(.applicationName) record sugar",
                 "\(\.$sugarInGramsEnum) grams of sugar in \(.applicationName)",
                 "\(.applicationName) \(\.$sugarInGramsEnum) gram",
                 "\(.applicationName) \(\.$sugarInGramsEnum) grams",


### PR DESCRIPTION
watchOS 10.4 broke several app shortcuts phrases that were previously working with no issues, this PR aims to try to alleviate this issue by changing some of the phrases.