### PR TITLE
fix: hide instant glucose indicator when same than current

### DIFF
--- a/OpenGluck/Records/Glucose/CurrentGlucose.swift
+++ b/OpenGluck/Records/Glucose/CurrentGlucose.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import OG
 
 struct CurrentGlucose: View {
     @EnvironmentObject var openGlückEnvironment: OpenGluckEnvironment
@@ -6,7 +7,11 @@ struct CurrentGlucose: View {
 
     var body: some View {
         if let currentGlucoseRecord = openGlückEnvironment.currentGlucoseRecord {
-            let currentInstantGlucoseRecord = openGlückEnvironment.currentInstantGlucoseRecord
+            let currentInstantGlucoseRecord: OpenGluckInstantGlucoseRecord? = if let currentInstantGlucoseRecord = openGlückEnvironment.currentInstantGlucoseRecord {
+                if currentInstantGlucoseRecord.timestamp > currentGlucoseRecord.timestamp { currentInstantGlucoseRecord } else { nil }
+            } else {
+                nil
+            }
 #if os(tvOS)
             GlucoseView(
                 glucoseRecord: .constant(currentGlucoseRecord),


### PR DESCRIPTION
Hide the current instant glucose when it has the same timestamp at the current scan/historic record, because in this case the instant would be trending straight, which doesn't add much value to understanding the trend.