### PR TITLE
fix: ios18, refresh in background

### DIFF
--- a/OpenGluck Phone App/PhoneAdvancedView.swift
+++ b/OpenGluck Phone App/PhoneAdvancedView.swift
@@ -89,8 +89,8 @@ struct PhoneAdvancedView: View {
     @AppStorage(WKDataKeys.phoneDeviceToken.keyValue, store: OpenGluckManager.userDefaults) var phoneDeviceToken: String = ""
     @AppStorage(WKDataKeys.watchDeviceToken.keyValue, store: OpenGluckManager.userDefaults) var watchDeviceToken: String = ""
     @AppStorage(WKDataKeys.enableUpdateBadgeCount.keyValue, store: OpenGluckManager.userDefaults) var enableUpdateBadgeCount: Bool = false
-#if OPENGLUCK_CONTACT_TRICK_IS_YES
     @EnvironmentObject var openGlückConnection: OpenGluckConnection
+#if OPENGLUCK_CONTACT_TRICK_IS_YES
     @AppStorage(WKDataKeys.enableContactTrick.keyValue, store: OpenGluckManager.userDefaults) var enableContactTrick: Bool = false
     @AppStorage(WKDataKeys.enableContactTrickDebug.keyValue, store: OpenGluckManager.userDefaults) var enableContactTrickDebug: Bool = false
 #endif

--- a/OpenGluck.xcodeproj/xcshareddata/xcschemes/OG Phone Widget Extension.xcscheme
+++ b/OpenGluck.xcodeproj/xcshareddata/xcschemes/OG Phone Widget Extension.xcscheme
@@ -56,8 +56,18 @@
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES"
       launchAutomaticallySubstyle = "2">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <RemoteRunnable
+         runnableDebuggingMode = "2"
+         BundleIdentifier = "com.apple.springboard">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9D8C667D29E3386800EB40E4"
+            BuildableName = "OG Phone Widget Extension.appex"
+            BlueprintName = "OG Phone Widget Extension"
+            ReferencedContainer = "container:OpenGluck.xcodeproj">
+         </BuildableReference>
+      </RemoteRunnable>
+      <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "9D50EBA629C79E2300CF69E6"
@@ -65,7 +75,14 @@
             BlueprintName = "OG Phone"
             ReferencedContainer = "container:OpenGluck.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </MacroExpansion>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "_XCWidgetKind"
+            value = "open-gluck.github.io.ios.widgets.current-glucose"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/OpenGluck/OpenGluck/OpenGluckConnection.swift
+++ b/OpenGluck/OpenGluck/OpenGluckConnection.swift
@@ -74,17 +74,20 @@ class OpenGluckConnection: ObservableObject, OpenGluckSyncClientDelegate {
         } else {
             nil
         }
-        if enableUpdateBadgeCount {
 #if os(iOS)
-            if let mostRecentTimestamp, -mostRecentTimestamp.timeIntervalSinceNow >= OpenGluckUI.maxGlucoseFreshnessTimeInterval {
-                try await UNUserNotificationCenter.current().setBadgeCount(0)
-            } else if let mgDl: Int = currentData.currentGlucoseRecord?.mgDl {
+        if let mostRecentTimestamp, -mostRecentTimestamp.timeIntervalSinceNow >= OpenGluckUI.maxGlucoseFreshnessTimeInterval {
+            try await UNUserNotificationCenter.current().setBadgeCount(0)
+        } else if let mgDl: Int = currentData.currentGlucoseRecord?.mgDl {
+            if enableUpdateBadgeCount {
                 try await UNUserNotificationCenter.current().setBadgeCount(instantMgDl ?? mgDl)
             }
-#endif
         }
+#endif
 #if !os(tvOS)
-        WidgetCenter.shared.reloadAllTimelines()
+        if let client = getClient() {
+            await client.recordLog("reloading all timelines because of \(becauseUpdateOf)")
+            WidgetCenter.shared.reloadAllTimelines()
+        }
 #endif
         return currentData
     }

--- a/OpenGluck/OpenGluck/OpenGluckEnvironmentUpdater.swift
+++ b/OpenGluck/OpenGluck/OpenGluckEnvironmentUpdater.swift
@@ -35,6 +35,7 @@ class OpenGluckEnvironment: ObservableObject
         self.lastInsulinRecords = nil
         self.lastLowRecords = nil
         self.revision = nil
+        self.lastAttemptAt = nil
     }
     
     var hasException: Bool {

--- a/OpenGluck/OpenGluck/OpenGluckEnvironmentUpdater.swift
+++ b/OpenGluck/OpenGluck/OpenGluckEnvironmentUpdater.swift
@@ -147,6 +147,7 @@ struct OpenGluckEnvironmentUpdater<Content>: View where Content: View {
             }
             .onReceive(NotificationCenter.default.publisher(for: WKApplication.willResignActiveNotification)) { _ in
                 print("WKApplication.willResignActiveNotification")
+                environment.clear()
             }
 #endif
     }

--- a/OpenGluck/Utils/Widgets/BaseWidget.swift
+++ b/OpenGluck/Utils/Widgets/BaseWidget.swift
@@ -99,7 +99,12 @@ class BaseWidgetProvider<Configuration, WidgetView> where Configuration: BaseWid
                     refreshTimelineAfter = in30m
                 }
 #endif
+//                #if os(iOS)
+//                // iOS 18 is very relunctant to refresh, even when we have enabled WidgetKit developer mode
+//                let timeline = Timeline(entries: try await entries, policy: .atEnd)
+//                #else
                 let timeline = Timeline(entries: try await entries, policy: .after(refreshTimelineAfter))
+//                #endif
                 completion(timeline)
             }
         }


### PR DESCRIPTION
- small fixes for iOS 18
- no longer keep old values when app is in background, to make sure values are correctly refreshed when app is re-launched