### PR TITLE
fix: GlucoseGraph should show even if no glucose records were found

### DIFF
--- a/OpenGluck/Records/Glucose/CurrentGlucoseView.swift
+++ b/OpenGluck/Records/Glucose/CurrentGlucoseView.swift
@@ -22,7 +22,10 @@ struct CurrentGlucoseView: View {
     @ViewBuilder var graph: some View {
         if openGlückEnvironment.hasTimedOut {
             ContentUnavailableView("Still Loading…", systemImage: "network.slash", description: Text("\nLoading data from OpenGlück server takes a while…\n\nCheck your network and configuration."))
-        } else if let lastGlucoseRecords = openGlückEnvironment.lastGlucoseRecords, let lastInsulinRecords = openGlückEnvironment.lastInsulinRecords, let lastLowRecords = openGlückEnvironment.lastLowRecords {
+        } else {
+            let lastGlucoseRecords: [OpenGluckGlucoseRecord] = openGlückEnvironment.lastGlucoseRecords ?? []
+            let lastInsulinRecords: [OpenGluckInsulinRecord] = openGlückEnvironment.lastInsulinRecords ?? []
+            let lastLowRecords: [OpenGluckLowRecord] = openGlückEnvironment.lastLowRecords ?? []
             GeometryReader { reader in
                 let _ = Task {
                     self.graphGeometry = reader.size


### PR DESCRIPTION
When no recent glucose data was found (like when your sensor has ended a few hours ago), the glucose graph would not render. This PR fixes this by still showing insulin and low records even without glucose records.